### PR TITLE
bump cirq requirement to 0.8.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cirq==0.8.1
+cirq==0.8.2
 seaborn
 sphinx
 ipython


### PR DESCRIPTION
This should fix errors due to protobuf collisions in Colab now that the external Colab has protobuf 3.12.2 as well. 