### PR TITLE
bump cirq requirement to 0.8.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cirq==0.8.1
+cirq==0.8.2
 seaborn
 sphinx
 ipython


### PR DESCRIPTION
This is to bump the Cirq version on master. 