### PR TITLE
Initial addition of quantum chess libraries

### DIFF
--- a/recirq/quantum_chess/__init__.py
+++ b/recirq/quantum_chess/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/recirq/quantum_chess/bit_utils.py
+++ b/recirq/quantum_chess/bit_utils.py
@@ -1,0 +1,86 @@
+# Copyright 2020 Google
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Utilities for converting to and from bit boards.
+"""
+from typing import List
+
+import cirq
+
+import recirq.quantum_chess.move as move
+
+
+def nth_bit_of(n: int, bit_board: int) -> bool:
+    """Returns the n-th bit of a 64-bit chess bitstring"""
+    return (bit_board >> n) % 2 == 1
+
+
+def set_nth_bit(n: int, bit_board: int, val: bool) -> int:
+    """Sets the nth bit of the bitstring to a specific value."""
+    return bit_board - (nth_bit_of(n, bit_board) << n) + (int(val) << n)
+
+
+def bit_to_qubit(n: int) -> cirq.Qid:
+    """Turns a number into a cirq Qubit."""
+    return cirq.NamedQubit(str(n))
+
+
+def num_ones(n: int) -> int:
+    """Number of ones in the binary representation of n."""
+    count = 0
+    while n > 0:
+        if n % 2 == 1:
+            count += 1
+        n = n // 2
+    return count
+
+
+def qubit_to_bit(q: cirq.LineQubit) -> int:
+    """Retrieves the number from a cirq Qubit's name.
+
+    Does not work for ancilla Qubits.
+    """
+    return int(q.name)
+
+
+def xy_to_bit(x: int, y: int) -> int:
+    """Transform x/y coordinates into a bitboard bit number."""
+    return y * 8 + x
+
+
+def square_to_bit(sq: str) -> int:
+    """Transform algebraic square notation into a bitboard bit number."""
+    return move.y_of(sq) * 8 + move.x_of(sq)
+
+
+def bit_to_square(bit: int) -> str:
+    """Transform a bitboard bit number into algebraic square notation."""
+    return move.to_square(bit % 8, bit // 8)
+
+
+def squares_to_bitboard(squares: List[str]) -> int:
+    """Transform a list of algebraic squares into a 64-bit board bitstring."""
+    bitboard = 0
+    for sq in squares:
+        bitboard += 1 << square_to_bit(sq)
+    return bitboard
+
+
+def bitboard_to_squares(bitboard: int) -> List[str]:
+    """Transform a 64-bit bitstring into a list of algebraic squares."""
+    squares = []
+    for n in range(64):
+        if nth_bit_of(n, bitboard):
+            squares.append(bit_to_square(n))
+    return squares

--- a/recirq/quantum_chess/bit_utils_test.py
+++ b/recirq/quantum_chess/bit_utils_test.py
@@ -1,0 +1,62 @@
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import cirq
+
+import recirq.quantum_chess.bit_utils as u
+
+
+def test_nth_bit_of():
+    assert u.nth_bit_of(0, 7)
+    assert u.nth_bit_of(1, 7)
+    assert u.nth_bit_of(2, 7)
+    assert not u.nth_bit_of(3, 7)
+    assert not u.nth_bit_of(0, 6)
+    assert u.nth_bit_of(1, 6)
+    assert u.nth_bit_of(2, 6)
+    assert not u.nth_bit_of(3, 6)
+
+
+def test_set_nth_bit():
+    assert u.set_nth_bit(0, 6, True) == 7
+    assert u.set_nth_bit(0, 6, False) == 6
+    assert u.set_nth_bit(2, 7, True) == 7
+    assert u.set_nth_bit(2, 7, False) == 3
+
+
+def test_bit_to_qubit():
+    assert u.bit_to_qubit(2) == cirq.NamedQubit("2")
+    assert u.bit_to_qubit(0) == cirq.NamedQubit("0")
+
+
+def test_qubit_to_bit():
+    assert u.qubit_to_bit(cirq.NamedQubit("2")) == 2
+    assert u.qubit_to_bit(cirq.NamedQubit("0")) == 0
+
+
+def test_square_to_bit():
+    assert u.square_to_bit('a1') == 0
+    assert u.square_to_bit('a2') == 8
+    assert u.square_to_bit('b2') == 9
+    assert u.square_to_bit('b1') == 1
+    assert u.square_to_bit('h8') == 63
+
+
+def test_squares_to_bitboard():
+    assert u.squares_to_bitboard(['a1', 'a2']) == 257
+    assert u.squares_to_bitboard(['a1', 'c1']) == 5
+
+
+def test_bitboard_to_squares():
+    assert u.bitboard_to_squares(257) == ['a1', 'a2']
+    assert u.bitboard_to_squares(5) == ['a1', 'c1']

--- a/recirq/quantum_chess/circuit_transformer.py
+++ b/recirq/quantum_chess/circuit_transformer.py
@@ -1,0 +1,337 @@
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import copy
+import random
+from typing import Dict, Iterable, List, Optional, Set
+
+import cirq
+
+import recirq.quantum_chess.controlled_iswap as controlled_iswap
+
+ADJACENCY = [(0, 1), (0, -1), (1, 0), (-1, 0)]
+
+
+class CircuitTransformer:
+    """Optimizer that will transform a circuit using NamedQubits
+    and transform it to use GridQubits.  This will use a breadth-first
+    search to find a suitable mapping into the specified grid.
+
+    It will then transform all operations to use the new qubits.
+    """
+
+    def __init__(self, device: cirq.Device):
+        self.device = device
+        self.mapping = None
+        self.starting_qubit = self.find_start_qubit(device.qubits)
+        self.qubit_list = device.qubits
+        super().__init__()
+
+    def qubits_within(self, depth: int, qubit: cirq.GridQubit,
+                      qubit_list: Iterable[cirq.GridQubit]) -> int:
+        """Returns the number of qubits within `depth` of the input `qubit`.
+
+        Args:
+          depth: how many connections to traverse
+          qubit: starting qubit
+          qubit_list: iterable of valid qubits
+        """
+        if qubit not in qubit_list:
+            return 0
+        if depth <= 0:
+            return 1
+        c = 1
+        for diff in ADJACENCY:
+            c += self.qubits_within(depth - 1, qubit + diff, qubit_list)
+        return c
+
+    def find_start_qubit(self, qubit_list: List[cirq.Qid],
+                         depth=3) -> cirq.GridQubit:
+        """Finds a reasonable starting qubit to start the mapping.
+
+        Uses the heuristic of the most connected qubit. """
+        best = None
+        best_count = -1
+        for q in qubit_list:
+            c = self.qubits_within(3, q, qubit_list)
+            if c > best_count:
+                best_count = c
+                best = q
+        return best
+
+    def edges_within(self, depth: int, node: cirq.Qid,
+                     graph: Dict[cirq.Qid, Iterable[cirq.Qid]]) -> int:
+        """Returns the number of qubits within `depth` of the specified `node`.
+
+        Args:
+          depth: how many connections to traverse
+          node: starting qubit
+          graph: edge graph of connections between qubits,
+            representing by a dictionary from qubit to adjacent qubits.
+        """
+        if depth <= 0:
+            return 1
+        c = 1
+        for adj_node in graph[node]:
+            c += self.edges_within(depth - 1, adj_node, graph)
+        return c
+
+    def find_start_node(self, graph: Dict[cirq.Qid, Iterable[cirq.Qid]],
+                        mapping: Dict[cirq.Qid, cirq.GridQubit]) -> cirq.Qid:
+        """Finds a reasonable starting qubit from an adjacency graph.
+
+        Args:
+            graph: edge graph of connections between qubits,
+            representing by a dictionary from qubit to adjacent qubits.
+        """
+        best = None
+        best_count = -1
+        for node in graph:
+            if node in mapping:
+                continue
+            c = self.edges_within(3, node, graph)
+            if c > best_count:
+                best_count = c
+                best = node
+        return best
+
+    def map_helper(self,
+                   cur_node: cirq.Qid,
+                   mapping: Dict[cirq.Qid, cirq.GridQubit],
+                   available_qubits: Set[cirq.GridQubit],
+                   graph: Dict[cirq.Qid, Iterable[cirq.Qid]],
+                   print_debug: bool = False) -> bool:
+        """Helper function to construct mapping.
+
+        Traverses a graph and performs recursive depth-first
+        search to construct a mapping one node at a time.
+        On failure, raises an error and back-tracks until a
+        suitable mapping can be found.  Assumes all qubits in
+        the graph are connected.
+
+        Args:
+          cur_node: node to examine.
+          mapping: current mapping of named qubits to `GridQubits`
+          available_qubits: current set of unassigned qubits
+          graph: adjacency graph of connections between qubits,
+            representing by a dictionary from qubit to adjacent qubits
+
+        Returns:
+          True if mapping was successful, False if no mapping was possible.
+        """
+        # cur_node is the named qubit
+        # cur_qubit is the currently assigned GridQubit
+        cur_qubit = mapping[cur_node]
+        if print_debug:
+            print(f'{cur_node} -> {cur_qubit}')
+
+        # Determine the list of adjacent nodes that still need to be mapped
+        nodes_to_map = []
+        for node in graph[cur_node]:
+            if node not in mapping:
+                # Unmapped node.
+                nodes_to_map.append(node)
+            else:
+                # Mapped adjacent node.
+                # Verify that the previous mapping is adjacent in the Grid.
+                if not mapping[node].is_adjacent(cur_qubit):
+                    if print_debug:
+                        print(f'Not adjacent {node} and {cur_node}')
+                    return False
+        if not nodes_to_map:
+            # All done with this node.
+            return True
+
+        # Find qubits that are adjacent in the grid
+        valid_adjacent_qubits = []
+        for a in ADJACENCY:
+            q = cur_qubit + a
+            if q in available_qubits:
+                valid_adjacent_qubits.append(q)
+
+        # Not enough adjacent qubits to map all qubits
+        if len(valid_adjacent_qubits) < len(nodes_to_map):
+            if print_debug:
+                print(f'Cannot fit adjacent nodes into {cur_node}')
+            return False
+
+        # Only map one qubit at a time
+        # This makes back-tracking easier.
+        node_to_map = nodes_to_map[0]
+
+        for node_to_try in valid_adjacent_qubits:
+            # Add proposed qubit to the mapping
+            # and remove it from available qubits
+            mapping[node_to_map] = node_to_try
+            available_qubits.remove(node_to_try)
+
+            # Recurse
+            # Move on to the qubit we just mapped.
+            # Then, come back to this node and
+            # map the rest of the adjacent nodes
+
+            success = self.map_helper(node_to_map, mapping, available_qubits,
+                                      graph)
+            if success:
+                success = self.map_helper(cur_node, mapping, available_qubits,
+                                          graph)
+
+            if not success:
+                # We have failed.  Undo this mapping and try another one.
+                del mapping[node_to_map]
+                available_qubits.add(node_to_try)
+            else:
+                #We have successfully mapped all qubits!
+                return True
+
+        # All available qubits were not valid.
+        # Fail upwards and back-track if possible.
+        if print_debug:
+            print('Warning: could not map all qubits!')
+            return False
+
+    def qubit_mapping(self,
+                      circuit: cirq.Circuit) -> Dict[cirq.Qid, cirq.GridQubit]:
+        """Create a mapping from NamedQubits to Grid Qubits
+
+       This function analyzes the circuit to determine which
+       qubits need to be adjacent, then maps to the grid of the device
+       based on the generated mapping.
+       """
+        # Build up an adjacency graph based on the circuits.
+        # Two qubit gates will turn into edges in the graph
+        g = {}
+        #Keep track of single qubits that don't interact.
+        sq = []
+        for m in circuit:
+            for op in m:
+                if len(op.qubits) == 1:
+                    if op.qubits[0] not in g:
+                        sq.append(op.qubits[0])
+                if len(op.qubits) == 2:
+                    q1, q2 = op.qubits
+                    if q1 not in g:
+                        g[q1] = []
+                    if q2 not in g:
+                        g[q2] = []
+                    if q1 in sq:
+                        sq.remove(q1)
+                    if q2 in sq:
+                        sq.remove(q2)
+                    if q2 not in g[q1]:
+                        g[q1].append(q2)
+                    if q1 not in g[q2]:
+                        g[q2].append(q1)
+        for q in g:
+            if len(g[q]) > 4:
+                raise ValueError(
+                    f'Qubit {q} needs more than 4 adjacent qubits!')
+
+        # Initialize mappings and available qubits
+        start_qubit = self.starting_qubit
+        mapping = {}
+        start_list = set(copy.copy(self.qubit_list))
+        start_list.remove(start_qubit)
+
+        last_node = None
+        cur_node = self.find_start_node(g, mapping)
+        if not cur_node and sq:
+            for q in sq:
+                start_qubit = self.find_start_qubit(start_list)
+                mapping[q] = start_qubit
+                start_list.remove(start_qubit)
+            self.mapping = mapping
+            return mapping
+
+        mapping[cur_node] = start_qubit
+
+        while last_node != cur_node:
+            # Depth first seach for a valid mapping
+            self.map_helper(cur_node, mapping, start_list, g)
+            last_node = cur_node
+            cur_node = self.find_start_node(g, mapping)
+            if not cur_node:
+                for q in sq:
+                    start_qubit = self.find_start_qubit(start_list)
+                    mapping[q] = start_qubit
+                    start_list.remove(start_qubit)
+                break
+            # assign a new start qubit
+            start_qubit = self.find_start_qubit(start_list)
+            mapping[cur_node] = start_qubit
+            start_list.remove(start_qubit)
+
+        if len(mapping) != len(g):
+            print('Warning: could not map all qubits!')
+        # Sanity check, ensure qubits not mapped twice
+        assert len(mapping) == len(set(mapping.values()))
+
+        self.mapping = mapping
+        return mapping
+
+    def optimize_circuit(self, circuit: cirq.Circuit) -> cirq.Circuit:
+        """ Creates a new qubit mapping for a circuit and transforms it.
+
+        This uses `qubit_mapping` to create a mapping from the qubits
+        in the circuit to the qubits on the device, then substitutes
+        in those qubits in the circuit and returns the new circuit.
+
+        Returns:
+          The circuit with the mapped qubits.
+        """
+        self.qubit_mapping(circuit)
+        return circuit.transform_qubits(lambda q: self.mapping[q])
+
+
+class SycamoreDecomposer(cirq.PointOptimizer):
+    """Optimizer that decomposes all three qubit operations into
+    sqrt-ISWAPs.
+
+    Currently supported are controlled ISWAPs with a single control
+    and control-X gates with multiple controls (TOFFOLI gates).:w
+    """
+
+    def optimization_at(self, circuit: cirq.Circuit, index: int,
+                        op: cirq.Operation
+                       ) -> Optional[cirq.PointOptimizationSummary]:
+        if len(op.qubits) > 3:
+            raise ValueError(f'Four qubit ops not yet supported: {op}')
+        new_ops = None
+        if op.gate == cirq.SWAP or op.gate == cirq.CNOT:
+            new_ops = cirq.google.optimized_for_sycamore(cirq.Circuit(op))
+        if isinstance(op, cirq.ControlledOperation):
+            qubits = op.sub_operation.qubits
+            if op.gate.sub_gate == cirq.ISWAP:
+                new_ops = controlled_iswap.controlled_iswap(
+                    *qubits, *op.controls)
+            if op.gate.sub_gate == cirq.ISWAP**-1:
+                new_ops = controlled_iswap.controlled_iswap(*qubits,
+                                                            *op.controls,
+                                                            inverse=True)
+            if op.gate.sub_gate == cirq.ISWAP**0.5:
+                new_ops = controlled_iswap.controlled_sqrt_iswap(
+                    *qubits, *op.controls)
+            if op.gate.sub_gate == cirq.ISWAP**-0.5:
+                new_ops = controlled_iswap.controlled_inv_sqrt_iswap(
+                    *qubits, *op.controls)
+            if op.gate.sub_gate == cirq.X:
+                if len(op.qubits) == 2:
+                    new_ops = cirq.google.optimized_for_sycamore(
+                        cirq.Circuit(cirq.CNOT(*op.controls, *qubits)))
+                if len(op.qubits) == 3:
+                    new_ops = cirq.google.optimized_for_sycamore(
+                        cirq.Circuit(cirq.TOFFOLI(*op.controls, *qubits)))
+        if new_ops:
+            return cirq.PointOptimizationSummary(clear_span=1,
+                                                 clear_qubits=op.qubits,
+                                                 new_operations=new_ops)

--- a/recirq/quantum_chess/circuit_transformer_test.py
+++ b/recirq/quantum_chess/circuit_transformer_test.py
@@ -1,0 +1,91 @@
+# Copyright 2020 Google
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import cirq
+
+import recirq.quantum_chess.circuit_transformer as ct
+import recirq.quantum_chess.quantum_moves as qm
+
+a1 = cirq.NamedQubit('a1')
+a2 = cirq.NamedQubit('a2')
+a3 = cirq.NamedQubit('a3')
+a4 = cirq.NamedQubit('a4')
+b1 = cirq.NamedQubit('b1')
+b2 = cirq.NamedQubit('b2')
+b3 = cirq.NamedQubit('b3')
+c1 = cirq.NamedQubit('c1')
+c2 = cirq.NamedQubit('c2')
+c3 = cirq.NamedQubit('c3')
+d1 = cirq.NamedQubit('d1')
+
+
+@pytest.mark.parametrize('device',
+                         (cirq.google.Sycamore23, cirq.google.Sycamore))
+def test_single_qubit_ops(device):
+    transformer = ct.CircuitTransformer(device)
+    c = cirq.Circuit(cirq.X(a1), cirq.X(a2), cirq.X(a3))
+    transformer.qubit_mapping(c)
+    c = transformer.optimize_circuit(c)
+    device.validate_circuit(c)
+
+
+@pytest.mark.parametrize('device',
+                         (cirq.google.Sycamore23, cirq.google.Sycamore))
+def test_single_qubit_with_two_qubits(device):
+    transformer = ct.CircuitTransformer(device)
+    c = cirq.Circuit(cirq.X(a1), cirq.X(a2), cirq.X(a3),
+                     cirq.ISWAP(a3, a4)**0.5)
+    transformer.qubit_mapping(c)
+    device.validate_circuit(transformer.optimize_circuit(c))
+
+
+@pytest.mark.parametrize('device',
+                         (cirq.google.Sycamore23, cirq.google.Sycamore))
+def test_three_split_moves(device):
+    transformer = ct.CircuitTransformer(device)
+    c = cirq.Circuit(qm.split_move(a1, a2, b1), qm.split_move(a2, a3, b3),
+                     qm.split_move(b1, c1, c2))
+    transformer.qubit_mapping(c)
+    device.validate_circuit(transformer.optimize_circuit(c))
+
+
+@pytest.mark.parametrize('device',
+                         (cirq.google.Sycamore23, cirq.google.Sycamore))
+def test_disconnected(device):
+    transformer = ct.CircuitTransformer(device)
+    c = cirq.Circuit(qm.split_move(a1, a2, a3), qm.split_move(a3, a4, d1),
+                     qm.split_move(b1, b2, b3), qm.split_move(c1, c2, c3))
+    transformer.qubit_mapping(c)
+    device.validate_circuit(transformer.optimize_circuit(c))
+
+
+@pytest.mark.parametrize('device',
+                         (cirq.google.Sycamore23, cirq.google.Sycamore))
+def test_move_around_square(device):
+    transformer = ct.CircuitTransformer(device)
+    c = cirq.Circuit(qm.normal_move(a1, a2), qm.normal_move(a2, b2),
+                     qm.normal_move(b2, b1), qm.normal_move(b1, a1))
+    transformer.qubit_mapping(c)
+    device.validate_circuit(transformer.optimize_circuit(c))
+
+
+@pytest.mark.parametrize('device',
+                         (cirq.google.Sycamore23, cirq.google.Sycamore))
+def test_split_then_merge(device):
+    transformer = ct.CircuitTransformer(device)
+    c = cirq.Circuit(qm.split_move(a1, a2, b1), qm.split_move(a2, a3, b3),
+                     qm.split_move(b1, c1, c2), qm.normal_move(c1, d1),
+                     qm.normal_move(a3, a4), qm.merge_move(a4, d1, a1))
+    transformer.qubit_mapping(c)
+    device.validate_circuit(transformer.optimize_circuit(c))

--- a/recirq/quantum_chess/constants.py
+++ b/recirq/quantum_chess/constants.py
@@ -1,0 +1,119 @@
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import cirq
+
+PIECES = {
+    0: '.',
+    1: 'P',
+    -1: 'p',
+    2: 'N',
+    -2: 'n',
+    3: 'B',
+    -3: 'b',
+    4: 'R',
+    -4: 'r',
+    5: 'Q',
+    -5: 'q',
+    6: 'K',
+    -6: 'k',
+}
+
+REV_PIECES = {
+    '.': 0,
+    'P': 1,
+    'p': -1,
+    'N': 2,
+    'n': -2,
+    'B': 3,
+    'b': -3,
+    'R': 4,
+    'r': -4,
+    'Q': 5,
+    'q': -5,
+    'K': 6,
+    'k': -6,
+}
+
+EMPTY = 0
+PAWN = 1
+KNIGHT = 2
+BISHOP = 3
+ROOK = 4
+QUEEN = 5
+KING = 6
+
+a1 = cirq.NamedQubit('a1')
+a2 = cirq.NamedQubit('a2')
+a3 = cirq.NamedQubit('a3')
+a4 = cirq.NamedQubit('a4')
+a5 = cirq.NamedQubit('a5')
+a6 = cirq.NamedQubit('a6')
+a7 = cirq.NamedQubit('a7')
+a8 = cirq.NamedQubit('a8')
+b1 = cirq.NamedQubit('b1')
+b2 = cirq.NamedQubit('b2')
+b3 = cirq.NamedQubit('b3')
+b4 = cirq.NamedQubit('b4')
+b5 = cirq.NamedQubit('b5')
+b6 = cirq.NamedQubit('b6')
+b7 = cirq.NamedQubit('b7')
+b8 = cirq.NamedQubit('b8')
+c1 = cirq.NamedQubit('c1')
+c2 = cirq.NamedQubit('c2')
+c3 = cirq.NamedQubit('c3')
+c4 = cirq.NamedQubit('c4')
+c5 = cirq.NamedQubit('c5')
+c6 = cirq.NamedQubit('c6')
+c7 = cirq.NamedQubit('c7')
+c8 = cirq.NamedQubit('c8')
+d1 = cirq.NamedQubit('d1')
+d2 = cirq.NamedQubit('d2')
+d3 = cirq.NamedQubit('d3')
+d4 = cirq.NamedQubit('d4')
+d5 = cirq.NamedQubit('d5')
+d6 = cirq.NamedQubit('d6')
+d7 = cirq.NamedQubit('d7')
+d8 = cirq.NamedQubit('d8')
+e1 = cirq.NamedQubit('e1')
+e2 = cirq.NamedQubit('e2')
+e3 = cirq.NamedQubit('e3')
+e4 = cirq.NamedQubit('e4')
+e5 = cirq.NamedQubit('e5')
+e6 = cirq.NamedQubit('e6')
+e7 = cirq.NamedQubit('e7')
+e8 = cirq.NamedQubit('e8')
+f1 = cirq.NamedQubit('f1')
+f2 = cirq.NamedQubit('f2')
+f3 = cirq.NamedQubit('f3')
+f4 = cirq.NamedQubit('f4')
+f5 = cirq.NamedQubit('f5')
+f6 = cirq.NamedQubit('f6')
+f7 = cirq.NamedQubit('f7')
+f8 = cirq.NamedQubit('f8')
+g1 = cirq.NamedQubit('g1')
+g2 = cirq.NamedQubit('g2')
+g3 = cirq.NamedQubit('g3')
+g4 = cirq.NamedQubit('g4')
+g5 = cirq.NamedQubit('g5')
+g6 = cirq.NamedQubit('g6')
+g7 = cirq.NamedQubit('g7')
+g8 = cirq.NamedQubit('g8')
+h1 = cirq.NamedQubit('h1')
+h2 = cirq.NamedQubit('h2')
+h3 = cirq.NamedQubit('h3')
+h4 = cirq.NamedQubit('h4')
+h5 = cirq.NamedQubit('h5')
+h6 = cirq.NamedQubit('h6')
+h7 = cirq.NamedQubit('h7')
+h8 = cirq.NamedQubit('h8')

--- a/recirq/quantum_chess/controlled_iswap.py
+++ b/recirq/quantum_chess/controlled_iswap.py
@@ -1,0 +1,138 @@
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Sequence, Iterable, List, Union, Optional
+
+import numpy as np
+
+import cirq
+from cirq.optimizers.two_qubit_to_fsim import \
+    _decompose_xx_yy_into_two_fsims_ignoring_single_qubit_ops, \
+    _fix_single_qubit_gates_around_kak_interaction
+
+
+def _decompose_xx_yy(
+        desired_interaction: Union[cirq.Operation, np.
+                                   ndarray, 'cirq.SupportsUnitary'],
+        *,
+        available_gate: cirq.Gate,
+        atol: float = 1e-8,
+        qubits: Optional[Sequence[cirq.Qid]] = None,
+) -> cirq.Circuit:
+    if qubits is None:
+        if isinstance(desired_interaction, cirq.Operation):
+            qubits = desired_interaction.qubits
+        else:
+            qubits = cirq.LineQubit.range(2)
+    kak = cirq.kak_decomposition(desired_interaction)
+
+    x, y, z = kak.interaction_coefficients
+    if abs(z) > atol:
+        raise ValueError(f'zz term present in {desired_interaction!r} -> {kak}')
+
+    if isinstance(available_gate, cirq.ISwapPowGate):
+        available_gate = cirq.FSimGate(-np.pi / 2 * available_gate.exponent, 0)
+
+    if min(x, y) > np.pi / 4 - atol and abs(
+            available_gate.phi) < atol and abs(available_gate.theta -
+                                               np.pi / 4) < atol:
+        ops = [
+            available_gate(*qubits),
+            cirq.Y.on_each(*qubits),
+            available_gate(*qubits),
+        ]
+    elif min(x, y) > np.pi / 4 - atol and abs(
+            available_gate.phi) < atol and abs(available_gate.theta +
+                                               np.pi / 4) < atol:
+        ops = [
+            available_gate(*qubits),
+            available_gate(*qubits),
+        ]
+    else:
+        ops = _decompose_xx_yy_into_two_fsims_ignoring_single_qubit_ops(
+            qubits=qubits,
+            fsim_gate=available_gate,
+            canonical_x_kak_coefficient=x,
+            canonical_y_kak_coefficient=y,
+        )
+    result = _fix_single_qubit_gates_around_kak_interaction(
+        desired=kak,
+        operations=ops,
+        qubits=qubits,
+    )
+    output = cirq.Circuit(result)
+    cirq.testing.assert_allclose_up_to_global_phase(
+        output.unitary(qubit_order=qubits),
+        cirq.unitary(desired_interaction),
+        atol=1e-4)
+    return output
+
+
+def controlled_iswap(a: cirq.Qid,
+                     b: cirq.Qid,
+                     c: cirq.Qid,
+                     inverse: Optional[bool] = False):
+    """Performs ISWAP(a,b).controlled_by(c).
+
+    Returns a generator of cirq.Operations.
+    """
+    available_gate = cirq.ISWAP**0.5
+    if inverse:
+        mul = -1
+    else:
+        mul = 1
+
+    def convert_op(op: cirq.Operation) -> cirq.OP_TREE:
+        if len(op.qubits) == 2:
+            return _decompose_xx_yy(op, available_gate=available_gate)
+        return op
+
+    def simplify_op(op: cirq.Operation) -> cirq.Operation:
+        if len(op.qubits) == 1:
+            return cirq.PhasedXZGate.from_matrix(
+                cirq.unitary(op)).on(*op.qubits)
+        if op.gate == cirq.FSimGate(-np.pi / 4, 0):
+            return cirq.ISWAP(*op.qubits)**0.5
+        return op
+
+    circuit = cirq.Circuit(
+        cirq.CNOT(b, a),
+        cirq.CNOT(c, b)**(-0.5 * mul),
+        cirq.CZ(a, b),
+        cirq.CNOT(c, b)**(0.5 * mul),
+        cirq.Y(a).controlled_by(b),
+        cirq.S(b)**-1,
+    )
+
+    converted_ops = cirq.Circuit(
+        convert_op(op) for op in circuit.all_operations())
+    cirq.optimizers.MergeSingleQubitGates().optimize_circuit(converted_ops)
+    cirq.optimizers.DropNegligible().optimize_circuit(converted_ops)
+    return cirq.Circuit(
+        simplify_op(op) for op in converted_ops.all_operations())
+
+
+def controlled_sqrt_iswap(a: cirq.Qid, b: cirq.Qid, c: cirq.Qid):
+    """Performs (ISWAP(a,b)i**0.5).controlled_by(c)"""
+    return cirq.google.optimized_for_sycamore(
+        cirq.Circuit(cirq.CNOT(a, b),
+                     cirq.TOFFOLI(c, b, a)**-0.5,
+                     cirq.CZ(c, b)**0.25, cirq.CNOT(a, b)))
+
+
+def controlled_inv_sqrt_iswap(a: cirq.Qid, b: cirq.Qid, c: cirq.Qid):
+    """Performs (ISWAP(a,b)i**0.5).controlled_by(c)"""
+    return cirq.google.optimized_for_sycamore(
+        cirq.Circuit(cirq.CNOT(a, b),
+                     cirq.TOFFOLI(c, b, a)**0.5,
+                     cirq.CZ(c, b)**-0.25, cirq.CNOT(a, b)))

--- a/recirq/quantum_chess/controlled_iswap_test.py
+++ b/recirq/quantum_chess/controlled_iswap_test.py
@@ -1,0 +1,76 @@
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import cirq
+import recirq.quantum_chess.controlled_iswap as controlled_iswap
+
+
+def test_controlled_iswap():
+    qubits = cirq.LineQubit.range(3)
+    result = controlled_iswap.controlled_iswap(qubits[0], qubits[1], qubits[2])
+    cirq.testing.assert_allclose_up_to_global_phase(
+        cirq.unitary(result),
+        cirq.unitary(
+            cirq.Circuit(
+                cirq.ISWAP(qubits[0], qubits[1]).controlled_by(qubits[2]))),
+        atol=1e-8,
+    )
+
+
+def test_controlled_inv_iswap():
+    qubits = cirq.LineQubit.range(3)
+    result = controlled_iswap.controlled_iswap(qubits[0],
+                                               qubits[1],
+                                               qubits[2],
+                                               inverse=True)
+    cirq.testing.assert_allclose_up_to_global_phase(
+        cirq.unitary(result),
+        cirq.unitary(
+            cirq.Circuit((cirq.ISWAP(qubits[0],
+                                     qubits[1])**-1).controlled_by(qubits[2]))),
+        atol=1e-8,
+    )
+
+
+def test_controlled_sqrt_iswap():
+    qubits = cirq.LineQubit.range(3)
+    result = controlled_iswap.controlled_sqrt_iswap(qubits[0], qubits[1],
+                                                    qubits[2])
+    import numpy
+    numpy.set_printoptions(linewidth=200, precision=3)
+    print(numpy.around(cirq.unitary(result), decimals=2))
+    cirq.testing.assert_allclose_up_to_global_phase(
+        cirq.unitary(result),
+        cirq.unitary(
+            cirq.Circuit(
+                (cirq.ISWAP(qubits[0],
+                            qubits[1])**0.5).controlled_by(qubits[2]))),
+        atol=1e-8,
+    )
+
+
+def test_controlled_inv_sqrt_iswap():
+    qubits = cirq.LineQubit.range(3)
+    result = controlled_iswap.controlled_inv_sqrt_iswap(qubits[0], qubits[1],
+                                                        qubits[2])
+    import numpy
+    numpy.set_printoptions(linewidth=200, precision=3)
+    print(numpy.around(cirq.unitary(result), decimals=2))
+    cirq.testing.assert_allclose_up_to_global_phase(
+        cirq.unitary(result),
+        cirq.unitary(
+            cirq.Circuit(
+                (cirq.ISWAP(qubits[0],
+                            qubits[1])**-0.5).controlled_by(qubits[2]))),
+        atol=1e-8,
+    )

--- a/recirq/quantum_chess/enums.py
+++ b/recirq/quantum_chess/enums.py
@@ -1,0 +1,44 @@
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import enum
+
+
+class MoveType(enum.Enum):
+    NULL_TYPE = 0
+    UNSPECIFIED_STANDARD = 1
+    JUMP = 2
+    SLIDE = 3
+    SPLIT_JUMP = 4
+    SPLIT_SLIDE = 5
+    MERGE_JUMP = 6
+    MERGE_SLIDE = 7
+    PAWN_STEP = 8
+    PAWN_TWO_STEP = 9
+    PAWN_CAPTURE = 10
+    PAWN_EP = 11
+    KS_CASTLE = 12
+    QS_CASTLE = 13
+
+
+class MoveVariant(enum.Enum):
+    UNSPECIFIED = 0
+    BASIC = 1
+    EXCLUDED = 2
+    CAPTURE = 3
+
+
+class ErrorMitigation(enum.Enum):
+    Nothing = 0  # No error mitigation
+    Error = 1  # Throw ValueError (for debugging)
+    Correct = 2  # Correct for errors through post-selection

--- a/recirq/quantum_chess/move.py
+++ b/recirq/quantum_chess/move.py
@@ -1,0 +1,118 @@
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import recirq.quantum_chess.enums as enums
+
+_ORD_A = ord('a')
+
+
+def to_rank(x: int) -> str:
+    """Returns the algebraic notation rank from the x coordinate."""
+    return chr(_ORD_A + x)
+
+
+def to_square(x: int, y: int) -> str:
+    """Returns the algebraic notation of a square."""
+    return chr(_ORD_A + x) + str(y + 1)
+
+
+def x_of(square: str) -> int:
+    """Returns x coordinate of an algebraic notation square (e.g. 'f4')."""
+    return ord(square[0]) - _ORD_A
+
+
+def y_of(square: str) -> int:
+    """Returns y coordinate of an algebraic notation square (e.g. 'f4')."""
+    return int(square[1]) - 1
+
+
+class Move:
+    """Container class that has the source and target of a quantum chess move.
+
+    If the move is a split move, it will have a target2.  If a merge move,
+    it will have a source2 attribute.
+
+    For moves that are input from the quantum chess board API, this will
+    have a move type and variant that determines what kind of move this is
+    (capture, exclusion, etc).
+    """
+
+    def __init__(self,
+                 source: str,
+                 target: str,
+                 *,
+                 source2: str = None,
+                 target2: str = None,
+                 move_type: enums.MoveType = None,
+                 move_variant: enums.MoveVariant = None):
+        self.source = source
+        self.source2 = source2
+        self.target = target
+        self.target2 = target2
+        self.move_type = move_type
+        self.move_variant = move_variant
+
+    def __eq__(self, other):
+        if isinstance(other, Move):
+            return (self.source == other.source and
+                    self.target == other.target and
+                    self.target2 == other.target2)
+        return False
+
+    @classmethod
+    def from_string(cls, str_to_parse: str):
+        """Creates a move from a string shorthand for tests.
+
+
+        Format=source,target,target2,source2:type:variant
+        with commas omitted.
+
+        if target2 is specified, then source2 should
+        be '--'
+
+        Examples:
+           'a1a2:JUMP:BASIC'
+           'b1a3c3:SPLIT_MOVE:BASIC'
+           'a3b1--c3:MERGE_MOVE:BASIC'
+        """
+        fields = str_to_parse.split(':')
+        if len(fields) != 3:
+            raise ValueError(f'Invalid move string {str_to_parse}')
+        source = fields[0][0:2]
+        target = fields[0][2:4]
+        move_type = enums.MoveType[fields[1]]
+        move_variant = enums.MoveVariant[fields[2]]
+        if len(fields[0]) <= 4:
+            return cls(source,
+                       target,
+                       move_type=move_type,
+                       move_variant=move_variant)
+        if len(fields[0]) <= 6:
+            return cls(source,
+                       target,
+                       target2=fields[0][4:6],
+                       move_type=move_type,
+                       move_variant=move_variant)
+        return cls(source,
+                   target,
+                   source2=fields[0][6:8],
+                   move_type=move_type,
+                   move_variant=move_variant)
+
+    def is_split_move(self) -> bool:
+        return self.target2 is not None
+
+    def __str__(self):
+        if self.is_split_move():
+            return self.source + '^' + self.target + self.target2
+        return self.source + self.target

--- a/recirq/quantum_chess/move_test.py
+++ b/recirq/quantum_chess/move_test.py
@@ -1,0 +1,20 @@
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import recirq.quantum_chess.move as move
+
+
+def test_equality():
+    assert move.Move('a1', 'b4') == move.Move('a1', 'b4')
+    assert move.Move('a1', 'b4') != move.Move('a1', 'b5')
+    assert move.Move('a1', 'b4') != "a1b4"

--- a/recirq/quantum_chess/puzzles_test.py
+++ b/recirq/quantum_chess/puzzles_test.py
@@ -1,0 +1,454 @@
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import cirq
+
+import recirq.quantum_chess.bit_utils as u
+import recirq.quantum_chess.enums as enums
+import recirq.quantum_chess.move as move
+import recirq.quantum_chess.quantum_board as qb
+import recirq.quantum_chess.quantum_board_test as quantum_board_test
+import recirq.quantum_chess.test_utils as test_utils
+
+ALL_CIRQ_BOARDS = quantum_board_test.ALL_CIRQ_BOARDS
+
+
+def assert_samples_in(b, possibilities):
+    return quantum_board_test.assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('solution,sq', (
+    ('b3d5--b7', 'd5'),
+    ('b7d5--b3', 'd5'),
+    ('b3f3--b7', 'f3'),
+    ('b7f3--b3', 'f3'),
+    ('b3f7--b7', 'f7'),
+    ('b7f7--b3', 'f7'),
+))
+def test_t1(solution, sq):
+    for board in ALL_CIRQ_BOARDS:
+        b = board.with_state(u.squares_to_bitboard(['b5', 'c5', 'd5']))
+        assert b.perform_moves('d5b3b7:SPLIT_SLIDE:BASIC',
+                               f'{solution}:MERGE_SLIDE:BASIC')
+        possibilities = [u.squares_to_bitboard(['b5', 'c5', sq])]
+        assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_t2(board):
+    b = board.with_state(u.squares_to_bitboard(['a7', 'c3', 'g1']))
+    did_it_move = b.perform_moves(
+        'c3b5e2:SPLIT_SLIDE:BASIC',
+        'a7a8:SLIDE:BASIC',
+        'e2g1:JUMP:CAPTURE',
+    )
+    if did_it_move:
+        possibilities = [u.squares_to_bitboard(['a8', 'g1'])]
+    else:
+        possibilities = [u.squares_to_bitboard(['a8', 'b5', 'g1'])]
+    assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_t3(board):
+    b = board.with_state(u.squares_to_bitboard(['f1', 'd7', 'e8']))
+    did_it_move = b.perform_moves(
+        'f1b5c4:SPLIT_SLIDE:BASIC',
+        'd7b5:SLIDE:CAPTURE',
+        'c4b5:SLIDE:CAPTURE',
+    )
+    possibilities = [u.squares_to_bitboard(['b5', 'e8'])]
+    assert_samples_in(b, possibilities)
+
+
+# Because of the long decomposition, is flaky with noisy simulator
+@pytest.mark.parametrize('board', quantum_board_test.BIG_CIRQ_BOARDS)
+def test_t4(board):
+    b = board.with_state(u.squares_to_bitboard(['e3', 'e6', 'b6', 'h6']))
+    did_it_move = b.perform_moves(
+        'e3d5f5:SPLIT_SLIDE:BASIC',
+        'e6d5:PAWN_CAPTURE:CAPTURE',
+        'f5h6:JUMP:CAPTURE',
+    )
+    if did_it_move:
+        possibilities = [u.squares_to_bitboard(['b6', 'e6', 'h6'])]
+    else:
+        possibilities = [u.squares_to_bitboard(['d5', 'b6', 'h6'])]
+    assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_t5(board):
+    b = board.with_state(u.squares_to_bitboard(['d4', 'a6', 'g6']))
+    did_it_move = b.perform_moves(
+        'd4a7g7:SPLIT_SLIDE:BASIC',
+        'a6a7:PAWN_STEP:EXCLUDED',
+    )
+    if did_it_move:
+        expected = u.squares_to_bitboard(['a7', 'g6', 'g7'])
+    else:
+        expected = u.squares_to_bitboard(['a7', 'g6', 'a6'])
+    assert_samples_in(b, [expected])
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_t6(board):
+    b = board.with_state(u.squares_to_bitboard(['h4', 'd5', 'g5']))
+    did_it_move = b.perform_moves(
+        'h4f5g6:SPLIT_JUMP:BASIC',
+        'g5g6:PAWN_STEP:EXCLUDED',
+    )
+    if did_it_move:
+        did_it_move = b.perform_moves(
+            'f5g7:JUMP:BASIC',
+            'd5d6:PAWN_STEP:BASIC',
+            'g7e6:JUMP:BASIC',
+            'd6d7:PAWN_STEP:BASIC',
+            'e6d8g7:SPLIT_JUMP:BASIC',
+            'd7d8:PAWN_STEP:EXCLUDED',
+        )
+        if did_it_move:
+            expected = u.squares_to_bitboard(['d8', 'g7', 'g6'])
+        else:
+            expected = u.squares_to_bitboard(['d8', 'd7', 'g6'])
+        assert_samples_in(b, [expected])
+    else:
+        did_it_move = b.perform_moves(
+            'g6e5:JUMP:BASIC',
+            'd5d6:PAWN_STEP:BASIC',
+            'e5d7g6:SPLIT_JUMP:BASIC',
+            'd6d7:PAWN_STEP:EXCLUDED',
+        )
+        if did_it_move:
+            expected = u.squares_to_bitboard(['d7', 'g6', 'g5'])
+        else:
+            expected = u.squares_to_bitboard(['d6', 'd7', 'g5'])
+        assert_samples_in(b, [expected])
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_t6(board):
+    b = board.with_state(u.squares_to_bitboard(['d4', 'a6', 'g6']))
+    did_it_move = b.perform_moves(
+        'd4a7g7:SPLIT_SLIDE:BASIC',
+        'a6a7:PAWN_STEP:EXCLUDED',
+    )
+    if did_it_move:
+        expected = u.squares_to_bitboard(['a7', 'g6', 'g7'])
+    else:
+        expected = u.squares_to_bitboard(['a7', 'g6', 'a6'])
+    assert_samples_in(b, [expected])
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_a1(board):
+    b = board.with_state(
+        u.squares_to_bitboard(
+            ['a8', 'b8', 'g8', 'f7', 'g7', 'g3', 'f2', 'f3', 'h1']))
+    did_it_move = b.perform_moves(
+        'h1h4h8:SPLIT_SLIDE:BASIC',
+        'g8f8h7:SPLIT_JUMP:BASIC',
+        'h8f8:SLIDE:CAPTURE',
+    )
+    if did_it_move:
+        possibilities = [
+            u.squares_to_bitboard(
+                ['a8', 'b8', 'f8', 'f7', 'g7', 'g3', 'f2', 'f3']),
+            u.squares_to_bitboard(
+                ['a8', 'b8', 'f8', 'f7', 'g7', 'g3', 'f2', 'f3', 'h7']),
+        ]
+    else:
+        possibilities = [
+            u.squares_to_bitboard(
+                ['a8', 'b8', 'f8', 'f7', 'g7', 'g3', 'f2', 'f3', 'h4']),
+            u.squares_to_bitboard(
+                ['a8', 'b8', 'h7', 'f7', 'g7', 'g3', 'f2', 'f3', 'h4']),
+        ]
+    assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_a2(board):
+    b = board.with_state(
+        u.squares_to_bitboard(
+            ['a8', 'b8', 'g8', 'f7', 'g7', 'g3', 'f2', 'f3', 'h1']))
+    did_it_move = b.perform_moves(
+        'h1h7h8:SPLIT_SLIDE:BASIC',
+        'g8f8:JUMP:BASIC',
+        'h8f8:SLIDE:CAPTURE',
+    )
+    if did_it_move:
+        possibilities = [
+            u.squares_to_bitboard(
+                ['a8', 'b8', 'f8', 'f7', 'g7', 'g3', 'f2', 'f3'])
+        ]
+    else:
+        possibilities = [
+            u.squares_to_bitboard(
+                ['a8', 'b8', 'f8', 'f7', 'g7', 'g3', 'f2', 'f3', 'h7'])
+        ]
+    assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_a3(board):
+    b = board.with_state(u.squares_to_bitboard(['f1', 'f2', 'f3']))
+    assert b.perform_moves(
+        'f1e1e2:SPLIT_JUMP:BASIC',
+        'f3e2:JUMP:CAPTURE',
+    )
+    possibilities = [
+        u.squares_to_bitboard(['e2', 'f2']),
+        u.squares_to_bitboard(['e1', 'e2', 'f2']),
+    ]
+    assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_a4(board):
+    b = board.with_state(
+        u.squares_to_bitboard(['g8', 'f7', 'g7', 'h7', 'g6', 'g3', 'g2', 'e1']))
+    assert b.perform_moves(
+        'e1e8:SLIDE:BASIC',
+        'g8f8h8:SPLIT_JUMP:BASIC',
+        'e8f8:SLIDE:CAPTURE',
+        'h8g8:JUMP:BASIC',
+        'f8g8:SLIDE:CAPTURE',
+    )
+    possibilities = [
+        u.squares_to_bitboard(['g8', 'f7', 'g7', 'h7', 'g6', 'g3', 'g2']),
+    ]
+    assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_a5(board):
+    b = qb.CirqBoard(
+        u.squares_to_bitboard([
+            'f2', 'g2', 'h2', 'g3', 'c4', 'c5', 'c6', 'f7', 'g7', 'h7', 'a8',
+            'h8'
+        ]))
+    did_it_move = b.perform_moves('c6b8d8:SPLIT_JUMP:BASIC',
+                                  'a8d8:SLIDE:CAPTURE')
+    if did_it_move:
+        expected = u.squares_to_bitboard(
+            ['f2', 'g2', 'h2', 'g3', 'c4', 'c5', 'f7', 'g7', 'h7', 'd8', 'h8'])
+    else:
+        expected = u.squares_to_bitboard([
+            'f2', 'g2', 'h2', 'g3', 'c4', 'c5', 'f7', 'g7', 'h7', 'a8', 'b8',
+            'h8'
+        ])
+    assert_samples_in(b, [expected])
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_a6(board):
+    b = qb.CirqBoard(
+        u.squares_to_bitboard(
+            ['a2', 'f2', 'g2', 'h2', 'g3', 'c6', 'h6', 'f7', 'g7', 'h7', 'h8']))
+    did_it_move = b.perform_moves(
+        'a2a8:SLIDE:BASIC',
+        'c6b8d8:SPLIT_JUMP:BASIC',
+        'a8d8:SLIDE:CAPTURE',
+    )
+    if did_it_move:
+        expected = u.squares_to_bitboard(
+            ['d8', 'f2', 'g2', 'h2', 'g3', 'h6', 'f7', 'g7', 'h7', 'h8'])
+    else:
+        expected = u.squares_to_bitboard(
+            ['a8', 'f2', 'g2', 'h2', 'g3', 'b8', 'h6', 'f7', 'g7', 'h7', 'h8'])
+    assert_samples_in(b, [expected])
+
+
+# Works on all cirq boards but is pretty slow.
+@pytest.mark.parametrize('board', quantum_board_test.BIG_CIRQ_BOARDS)
+def test_a6_alternate(board):
+    b = board.with_state(
+        u.squares_to_bitboard(
+            ['a2', 'f2', 'g2', 'h2', 'g3', 'c6', 'h6', 'f7', 'g7', 'h7', 'h8']))
+    did_it_move = b.perform_moves(
+        'a2a8:SLIDE:BASIC',
+        'c6b8d8:SPLIT_JUMP:BASIC',
+        'a8b8:SLIDE:CAPTURE',
+        'h6d6:SLIDE:BASIC',
+        'b8h8:SLIDE:CAPTURE',
+    )
+    if did_it_move:
+        expected = u.squares_to_bitboard(
+            ['f2', 'g2', 'h2', 'g3', 'd6', 'f7', 'g7', 'h7', 'h8'])
+    else:
+        expected = u.squares_to_bitboard(
+            ['b8', 'f2', 'g2', 'h2', 'g3', 'd8', 'd6', 'f7', 'g7', 'h7', 'h8'])
+    assert_samples_in(b, [expected])
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_a7(board):
+    b = board.with_state(
+        u.squares_to_bitboard(
+            ['a2', 'c2', 'e2', 'g2', 'h2', 'a3', 'h3', 'f6', 'g7', 'h7', 'h8']))
+    did_it_move = b.perform_moves('c2a1e1:SPLIT_JUMP:BASIC',
+                                  'e2e1:PAWN_STEP:EXCLUDED')
+    if did_it_move:
+        possibilities = [
+            u.squares_to_bitboard([
+                'a1', 'a2', 'e1', 'g2', 'h2', 'a3', 'h3', 'f6', 'g7', 'h7', 'h8'
+            ])
+        ]
+        assert_samples_in(b, possibilities)
+        return
+    b.perform_moves(
+        'a3c2:JUMP:BASIC',
+        'a2a1:PAWN_STEP:BASIC',
+        'c2a1:JUMP:CAPTURE',
+    )
+    possibilities = [
+        u.squares_to_bitboard(
+            ['a1', 'e1', 'e2', 'g2', 'h2', 'h3', 'f6', 'g7', 'h7', 'h8'])
+    ]
+    assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_a8(board):
+    b = qb.CirqBoard(u.squares_to_bitboard(['a1', 'd1', 'c5', 'a7', 'h8']))
+    did_it_move = b.perform_moves('c5a4a6:SPLIT_JUMP:BASIC',
+                                  'a1a6:SLIDE:CAPTURE')
+    if did_it_move:
+        possibilities = [u.squares_to_bitboard(['a6', 'd1', 'a7', 'h8'])]
+    else:
+        possibilities = [u.squares_to_bitboard(['a1', 'd1', 'a4', 'a7', 'h8'])]
+    assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_a9(board):
+    b = qb.CirqBoard(
+        u.squares_to_bitboard(
+            ['h1', 'e2', 'f2', 'g2', 'e3', 'h3', 'g6', 'h6', 'c7']))
+    did_it_move = b.perform_moves(
+        'e2e3:SLIDE:CAPTURE',
+        'c7f4h2:SPLIT_SLIDE:BASIC',
+        'e3h6:SLIDE:CAPTURE',
+    )
+    if did_it_move:
+        possibilities = [
+            u.squares_to_bitboard(['h1', 'f2', 'g2', 'h3', 'g6', 'h6', 'h2'])
+        ]
+    else:
+        possibilities = [
+            u.squares_to_bitboard(
+                ['h1', 'f2', 'g2', 'e3', 'h3', 'g6', 'h6', 'f4'])
+        ]
+    assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_a10(board):
+    b = board.with_state(
+        u.squares_to_bitboard([
+            'd1', 'f1', 'g1', 'f2', 'g2', 'h2', 'd3', 'd4', 'd5', 'd6', 'e6',
+            'g6', 'h6', 'g7', 'b8', 'f8'
+        ]))
+    did_it_move = b.perform_moves(
+        'd3c5e5:SPLIT_JUMP:BASIC',
+        'g6h7:JUMP:BASIC',
+        'c5d7--e5:MERGE_JUMP:BASIC',
+        'b8d8:SLIDE:BASIC',
+        'd7f8:JUMP:CAPTURE',
+    )
+    assert did_it_move
+    possibilities = [
+        u.squares_to_bitboard([
+            'd1', 'f1', 'g1', 'f2', 'g2', 'h2', 'd4', 'd5', 'd6', 'e6', 'h7',
+            'h6', 'g7', 'd8', 'f8'
+        ])
+    ]
+    assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_a11(board):
+    b = qb.CirqBoard(
+        u.squares_to_bitboard([
+            'd1', 'e1', 'h1', 'd2', 'e2', 'f2', 'g2', 'e3', 'e6', 'd7', 'e7',
+            'f7'
+        ]))
+    did_it_move = b.perform_moves(
+        'e3c2f1:SPLIT_JUMP:BASIC',
+        'e1g1:KS_CASTLE:BASIC',
+    )
+    if did_it_move:
+        possibilities = [
+            u.squares_to_bitboard([
+                'd1', 'f1', 'g1', 'd2', 'e2', 'f2', 'g2', 'c2', 'e6', 'd7',
+                'e7', 'f7'
+            ]),
+        ]
+    else:
+        possibilities = [
+            u.squares_to_bitboard([
+                'd1', 'e1', 'h1', 'd2', 'e2', 'f2', 'g2', 'f1', 'e6', 'd7',
+                'e7', 'f7'
+            ]),
+        ]
+
+    assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_blocked_split_slide(board):
+    b = qb.CirqBoard(u.squares_to_bitboard(['d1', 'g1']))
+    assert b.perform_moves(
+        'g1e2h3:SPLIT_JUMP:BASIC',
+        'd1b3g4:SPLIT_SLIDE:BASIC',
+    )
+    test_utils.assert_sample_distribution(
+        b, {
+            u.squares_to_bitboard(['e2', 'b3']): 1 / 2,
+            u.squares_to_bitboard(['h3', 'b3']): 1 / 4,
+            u.squares_to_bitboard(['h3', 'g4']): 1 / 4,
+        })
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_blocked_split_slide_merge1(board):
+    b = qb.CirqBoard(u.squares_to_bitboard(['d1', 'g1']))
+    assert b.perform_moves(
+        'g1e2h3:SPLIT_JUMP:BASIC',
+        'd1b3g4:SPLIT_SLIDE:BASIC',
+        'b3e6--g4:MERGE_SLIDE:BASIC',
+    )
+    test_utils.assert_sample_distribution(
+        b, {
+            u.squares_to_bitboard(['e2', 'e6']): 1 / 4,
+            u.squares_to_bitboard(['e2', 'g4']): 1 / 4,
+            u.squares_to_bitboard(['h3', 'e6']): 1 / 2,
+        })
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_blocked_split_slide_merge2(board):
+    b = qb.CirqBoard(u.squares_to_bitboard(['d1', 'g1']))
+    assert b.perform_moves(
+        'g1e2h3:SPLIT_JUMP:BASIC',
+        'd1b3g4:SPLIT_SLIDE:BASIC',
+        'g4e6--b3:MERGE_SLIDE:BASIC',
+    )
+    test_utils.assert_sample_distribution(
+        b, {
+            u.squares_to_bitboard(['e2', 'e6']): 1 / 4,
+            u.squares_to_bitboard(['e2', 'b3']): 1 / 4,
+            u.squares_to_bitboard(['h3', 'e6']): 1 / 2,
+        })

--- a/recirq/quantum_chess/quantum_board.py
+++ b/recirq/quantum_chess/quantum_board.py
@@ -1,0 +1,844 @@
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Dict, List, Optional, Tuple
+
+import cirq
+
+from recirq.quantum_chess.bit_utils import (
+    bit_to_qubit,
+    nth_bit_of,
+    num_ones,
+    qubit_to_bit,
+    set_nth_bit,
+    square_to_bit,
+    xy_to_bit,
+)
+import recirq.quantum_chess.circuit_transformer as circuit_transformer
+import recirq.quantum_chess.enums as enums
+import recirq.quantum_chess.move as move
+import recirq.quantum_chess.quantum_moves as qm
+
+
+class CirqBoard:
+    """Implementation of Quantum Board API using cirq sampler.
+
+    This class implements a quantum chess board by representing
+    it as a 64-bit integer that represents the initial state as
+    well as the classical components of the board.  It also
+    contains a `cirq.Circuit` that represents a circuit that
+    can be executed to generate samples for the quantum portions
+    of the board.
+
+    This board implements all measurements of intermediate moves
+    through post-selection.  Measurements are moved to ancilla
+    qubits and measured as part of a final measurement.  Results
+    are then post-selected to retrieve samples that match board
+    positions with the same measurements.
+
+    Args:
+        init_basis_state: 64-bit bitboard defining the initial
+            classical state of the board.
+        sampler: a Cirq.sampler that can simulate or execute
+            quantum circuits to run.  Defaults to cirq simulator.
+        device: a cirq.Device that should run the circuit.  This
+            device should use GridQubits.  If specified, qubit
+            mapping and decomposition will be performed to transform
+            the circuit to run on the device.
+        error_mitigation:  If enabled, detects when pieces have
+            unexplainably disappeared or appeared and either throws
+            an error or post-selects the result away.
+        noise_mitigation: Threshold of samples to overcome in order
+            to be considered not noise.
+    """
+
+    def __init__(self,
+                 init_basis_state: int,
+                 sampler: cirq.Sampler = cirq.Simulator(),
+                 device: Optional[cirq.Device] = None,
+                 error_mitigation: Optional[
+                     enums.ErrorMitigation] = enums.ErrorMitigation.Nothing,
+                 noise_mitigation: Optional[float] = 0.0):
+        self.device = device
+        self.sampler = sampler
+        if device is not None:
+            self.transformer = circuit_transformer.CircuitTransformer(device)
+        self.with_state(init_basis_state)
+        self.error_mitigation = error_mitigation
+        self.noise_mitigation = noise_mitigation
+
+    def with_state(self, basis_state: int) -> 'CirqBoard':
+        """Resets the board with a specific classical state."""
+        self.state = basis_state
+        self.allowed_pieces = set()
+        self.allowed_pieces.add(num_ones(self.state))
+        self.entangled_squares = set()
+        self.post_selection = {}
+        self.circuit = cirq.Circuit()
+        self.ancilla_count = 0
+        self.clear_debug_log()
+        return self
+
+    def clear_debug_log(self) -> None:
+        self.debug_log = ''
+
+    def print_debug_log(self, clear_log: bool = True) -> None:
+        print(self.debug_log)
+        if clear_log:
+            self.clear_debug_log()
+
+    def perform_moves(self, *moves) -> bool:
+        """Performs a list of moves, specified as strings.
+
+      Useful for short-hand versions of tests.
+
+      Returns the measurement for the final move
+      """
+        did_it_move = False
+        for m in moves:
+            did_it_move = self.do_move(move.Move.from_string(m))
+        return did_it_move
+
+    def undo_last_move(self) -> bool:
+        """Undo is not yet implemented."""
+        return False
+
+    def sample_with_ancilla(self, num_samples: int
+                           ) -> Tuple[List[int], List[Dict[str, int]]]:
+        """Samples the board and returns square and ancilla measurements.
+
+        Sends the current circuit to the sampler then retrieves the results.
+        May return less samples than num_samples due to post-selection.
+
+        Returns the results as a tuple.  The first entry is the list of
+        measured squares, as represented by a 64-bit int bitboard.
+        The second value is a list of ancilla values, as represented as a
+        dictionary from ancilla name to value (0 or 1).
+        """
+        measure_circuit = self.circuit.copy()
+        ancilla = []
+        error_count = 0
+        noise_count = 0
+        post_count = 0
+        if self.entangled_squares:
+            qubits = sorted(self.entangled_squares)
+            measure_moment = cirq.Moment(
+                cirq.measure(q, key=q.name) for q in qubits)
+            measure_circuit.append(measure_moment)
+
+            # Try to guess the appropriate number of repetitions needed
+            # Assume that each post_selection is about 50/50
+            # Noise and error mitigation will discard reps, so increase
+            # the total number of repetitions to compensate
+            if len(self.post_selection) > 1:
+                num_reps = num_samples * (2**(len(self.post_selection) + 1))
+            else:
+                num_reps = num_samples
+            if self.error_mitigation == enums.ErrorMitigation.Correct:
+                num_reps *= 2
+            noise_threshold = self.noise_mitigation * num_samples
+            if self.noise_mitigation > 0:
+                num_reps *= 3
+            if num_reps < 100:
+                num_reps = 100
+
+            self.debug_log += (f'Running circuit with {num_reps} reps '
+                               f'to get {num_samples} samples:\n'
+                               f'{str(measure_circuit)}\n')
+
+            # Translate circuit to grid qubits and sqrtISWAP gates
+            if self.device is not None:
+                # Decompose 3-qubit operations
+                circuit_transformer.SycamoreDecomposer().optimize_circuit(
+                    measure_circuit)
+                # Create NamedQubit to GridQubit mapping and transform
+                measure_circuit = self.transformer.optimize_circuit(
+                    measure_circuit)
+
+                # For debug, ensure that the circuit correctly validates
+                self.device.validate_circuit(measure_circuit)
+
+            # Run the circuit using the provided sampler (simulator or hardware)
+            results = self.sampler.run(measure_circuit, repetitions=num_reps)
+
+            # Parse the results
+            rtn = []
+            noise_buffer = {}
+            data = results.data
+            for rep in range(num_reps):
+                new_sample = self.state
+                new_ancilla = {}
+
+                # Go through the results and discard any results
+                # that disagree with our pre-defined post-selection criteria
+                post_selected = True
+                for qubit in self.post_selection.keys():
+                    key = qubit.name
+                    if key in data.columns:
+                        result = data.at[rep, key]
+                        if result != self.post_selection[qubit]:
+                            post_selected = False
+                if not post_selected:
+                    post_count += 1
+                    continue
+
+                # Translate qubit results into a 64-bit chess board
+                for qubit in qubits:
+                    key = qubit.name
+                    result = data.at[rep, key]
+                    # Ancilla bits should not be part of the chess board
+                    if 'anc' not in key:
+                        bit = qubit_to_bit(qubit)
+                        new_sample = set_nth_bit(bit, new_sample, result)
+                    else:
+                        new_ancilla[key] = result
+
+                # Perform Error Mitigation
+                if self.error_mitigation != enums.ErrorMitigation.Nothing:
+                    # Discard boards that have the wrong number of pieces
+                    if num_ones(new_sample) not in self.allowed_pieces:
+                        if self.error_mitigation == enums.ErrorMitigation.Error:
+                            raise ValueError(
+                                'Error detected, '
+                                f'pieces allowed = {self.allowed_pieces}'
+                                f'but got {num_ones(new_sample)}')
+                        if self.error_mitigation == enums.ErrorMitigation.Correct:
+                            error_count += 1
+                            continue
+
+                # Noise mitigation
+                if self.noise_mitigation > 0.0:
+                    # Ignore samples up to a threshold
+                    if new_sample not in noise_buffer:
+                        noise_buffer[new_sample] = 0
+                    noise_buffer[new_sample] += 1
+                    if noise_buffer[new_sample] < noise_threshold:
+                        noise_count += 1
+                        continue
+
+                # This sample has passed noise and error mitigation
+                # Record it as a proper sample
+                rtn.append(new_sample)
+                ancilla.append(new_ancilla)
+                if len(rtn) >= num_samples:
+                    self.debug_log += (
+                        f'Discarded {error_count} from error mitigation '
+                        f'{noise_count} from noise and '
+                        f'{post_count} from post-selection\n')
+                    return (rtn, ancilla)
+        else:
+            rtn = [self.state] * num_samples
+            self.debug_log += (
+                f'Discarded {error_count} from error mitigation '
+                f'{noise_count} from noise and {post_count} from post-selection\n'
+            )
+        return (rtn, ancilla)
+
+    def sample(self, num_samples: int) -> List[int]:
+        """Samples the board and returns square and ancilla measurements.
+
+        Sends the current circuit to the sampler then retrieves the results.
+
+        Returns the results as a list of bitboards.
+        """
+        rtn = []
+        while len(rtn) < num_samples:
+            samples, _ = self.sample_with_ancilla(num_samples)
+            rtn = rtn + samples
+        return rtn[:num_samples]
+
+    def get_probability_distribution(self,
+                                     repetitions: int = 1000) -> List[float]:
+        """Returns the probability of a piece being in each square.
+
+        The values are returned as a list in the same ordering as a
+        bitboard.
+        """
+        samples = self.sample(repetitions)
+        counts = [0] * 64
+        for sample in samples:
+            for bit in range(64):
+                if nth_bit_of(bit, sample):
+                    counts[bit] += 1
+        for bit in range(64):
+            counts[bit] = float(counts[bit]) / float(repetitions)
+        return counts
+
+    def get_full_squares_bitboard(self, repetitions: int = 1000) -> int:
+        """Retrieves which squares are marked as full.
+
+        This information is created using a representative set of
+        samples (defined by the repetitions argument) to determine
+        which squares are occupied on at least one board.
+
+        Returns a bitboard.
+        """
+        samples = self.sample(repetitions)
+        full_squares = 0
+        for bit in range(64):
+            for sample in samples:
+                if nth_bit_of(bit, sample):
+                    full_squares = set_nth_bit(bit, full_squares, 1)
+                    break
+        return full_squares
+
+    def get_empty_squares_bitboard(self, repetitions: int = 1000) -> int:
+        """Retrieves which squares are marked as full.
+
+        This information is created using a representative set of
+        samples (defined by the repetitions argument) to determine
+        which squares are empty on all boards.
+
+        Returns a bitboard.
+        """
+        samples = self.sample(repetitions)
+        empty_squares = (1 << 64) - 1
+        for bit in range(64):
+            for sample in samples:
+                if nth_bit_of(bit, sample):
+                    empty_squares = set_nth_bit(bit, empty_squares, 0)
+                    break
+        return empty_squares
+
+    def add_entangled(self, *qubits):
+        """Adds squares as entangled.
+
+        This enables measuring of the square by the quantum circuit
+        and also adds a piece in the square to the circuit if the
+        classical register is currently set to one.
+        """
+        for qubit in qubits:
+            if qubit not in self.entangled_squares:
+                self.entangled_squares.add(qubit)
+                if nth_bit_of(qubit_to_bit(qubit), self.state):
+                    self.circuit.append(qm.place_piece(qubit))
+
+    def new_ancilla(self) -> cirq.Qid:
+        """Adds a new ancilla to the circuit and returns its value."""
+        new_name = f'anc{self.ancilla_count}'
+        new_qubit = cirq.NamedQubit(new_name)
+        self.ancilla_count += 1
+        return new_qubit
+
+    def unhook(self, qubit: cirq.Qid) -> cirq.Qid:
+        """Removes a qubit from the quantum portion of the board.
+
+        This exchanges all mentions of the qubit in the circuit
+        with a new ancilla qubit and removes it from the set of
+        entangled squares.i
+        """
+        if qubit not in self.entangled_squares:
+            return
+
+        # Create a new ancilla qubit to replace the qubit with
+        new_qubit = self.new_ancilla()
+
+        # Replace operations using the qubit with the ancilla instead
+        self.circuit = self.circuit.transform_qubits(lambda q: new_qubit
+                                                     if q == qubit else q)
+
+        # Remove the qubit from the list of active qubits
+        self.entangled_squares.remove(qubit)
+        self.entangled_squares.add(new_qubit)
+        return new_qubit
+
+    def path_qubits(self, source: str, target: str) -> List[cirq.Qid]:
+        """Returns all entangled qubits (or classical pieces)
+        between source and target.
+
+        Source and target should be specified in algebraic notation,
+        such as 'f4'.
+        """
+        rtn = []
+        xs = move.x_of(source)
+        ys = move.y_of(source)
+        xt = move.x_of(target)
+        yt = move.y_of(target)
+        if xt > xs:
+            dx = 1
+        elif xt < xs:
+            dx = -1
+        else:
+            dx = 0
+        if yt > ys:
+            dy = 1
+        elif yt < ys:
+            dy = -1
+        else:
+            dy = 0
+        max_slide = max(abs(xs - xt), abs(ys - yt))
+        if max_slide > 1:
+            for t in range(1, max_slide):
+                path_bit = xy_to_bit(xs + dx * t, ys + dy * t)
+                path_qubit = bit_to_qubit(path_bit)
+                if (path_qubit in self.entangled_squares or
+                        nth_bit_of(path_bit, self.state)):
+                    rtn.append(path_qubit)
+        return rtn
+
+    def create_path_ancilla(self, path_qubits: List[cirq.Qid]) -> cirq.Qid:
+        """Creates an ancilla that is anti-controlled by the qubits
+        in the path."""
+        path_ancilla = self.new_ancilla()
+        self.circuit.append(
+            qm.controlled_operation(cirq.X, [path_ancilla], [], path_qubits))
+        return path_ancilla
+
+    def set_castle(self, sbit: int, rook_sbit: int, tbit: int,
+                   rook_tbit: int) -> None:
+        """Adjusts classical bits for a castling operation."""
+        self.state = set_nth_bit(sbit, self.state, 0)
+        self.state = set_nth_bit(rook_sbit, self.state, 0)
+        self.state = set_nth_bit(tbit, self.state, 1)
+        self.state = set_nth_bit(rook_tbit, self.state, 1)
+
+    def queenside_castle(self, squbit: int, rook_squbit: int, tqubit: int,
+                         rook_tqubit: int, b_qubit: int) -> None:
+        """Performs a queenside castling operation."""
+        self.add_entangled(squbit, tqubit, rook_squbit, rook_tqubit)
+        self.circuit.append(
+            qm.queenside_castle(squbit, rook_squbit, tqubit, rook_tqubit,
+                                b_qubit))
+
+    def post_select_on(self, qubit: cirq.Qid) -> int:
+        """Adds a post-selection requirement to the circuit,
+
+        Performs a single sample of the qubit to get a value.
+        Adjusts the post-selection requirements dictionary to this value.
+        If this qubit is a square qubit, it adjusts the classical register
+        to match the sample result.
+
+        Returns: the sample result as 1 or 0.
+        """
+        if 'anc' in qubit.name:
+            ancilla_result = []
+            while len(ancilla_result) == 0:
+                _, ancilla_result = self.sample_with_ancilla(10)
+            result = ancilla_result[0][qubit.name]
+            self.post_selection[qubit] = result
+        else:
+            bit = qubit_to_bit(qubit)
+            result = nth_bit_of(bit, self.sample(1)[0])
+            if qubit in self.entangled_squares:
+                ancillary = self.unhook(qubit)
+                self.post_selection[ancillary] = result
+            self.state = set_nth_bit(bit, self.state, result)
+        return result
+
+    def do_move(self, m: move.Move) -> int:
+        """Performs a move on the quantum board.
+
+        Based on the type and variant of the move requested,
+        this function augments the circuit, classical registers,
+        and post-selection criteria to perform the board.
+
+        Returns:  The measurement that was performed, or 1 if
+            no measurement was required.
+        """
+        if not m.move_type:
+            raise ValueError('No Move defined')
+        if m.move_type == enums.MoveType.NULL_TYPE:
+            raise ValueError('Move has null type')
+        if m.move_type == enums.MoveType.UNSPECIFIED_STANDARD:
+            raise ValueError('Move type is unspecified')
+        sbit = square_to_bit(m.source)
+        tbit = square_to_bit(m.target)
+        squbit = bit_to_qubit(sbit)
+        tqubit = bit_to_qubit(tbit)
+
+        if (m.move_variant == enums.MoveVariant.CAPTURE or
+                m.move_type == enums.MoveType.PAWN_EP or
+                m.move_type == enums.MoveType.PAWN_CAPTURE):
+            # TODO: figure out if it is a deterministic capture.
+            for val in list(self.allowed_pieces):
+                self.allowed_pieces.add(val - 1)
+
+        if m.move_type == enums.MoveType.PAWN_EP:
+            # For en passant, first determine the square of the pawn being
+            # captured, which should be next to the target.
+            if m.target[1] == '6':
+                epbit = square_to_bit(m.target[0] + '5')
+            elif m.target[1] == '2':
+                epbit = square_to_bit(m.target[0] + '4')
+            else:
+                raise ValueError(f'Invalid en passant target {m.target}')
+            epqubit = bit_to_qubit(epbit)
+
+            # For the classical version, set the bits appropriately
+            if (epqubit not in self.entangled_squares and
+                    squbit not in self.entangled_squares and
+                    tqubit not in self.entangled_squares):
+                if (not nth_bit_of(epbit, self.state) or
+                        not nth_bit_of(sbit, self.state) or
+                        nth_bit_of(tbit, self.state)):
+                    raise ValueError('Invalid classical e.p. move')
+                    return 0
+                self.state = set_nth_bit(epbit, self.state, 0)
+                self.state = set_nth_bit(sbit, self.state, 0)
+                self.state = set_nth_bit(tbit, self.state, 1)
+                return 1
+
+            # If any squares are quantum, it's a quantum move
+            self.add_entangled(squbit, tqubit, epqubit)
+
+            # Capture e.p. post-select on the source
+            if m.move_variant == enums.MoveVariant.CAPTURE:
+                is_there = self.post_select_on(squbit)
+                if not is_there:
+                    return 0
+                self.add_entangled(squbit)
+                path_ancilla = self.new_ancilla()
+                captured_ancilla = self.new_ancilla()
+                captured_ancilla2 = self.new_ancilla()
+                # capture e.p. has a special circuit
+                self.circuit.append(
+                    qm.capture_ep(squbit, tqubit, epqubit, self.new_ancilla(),
+                                  self.new_ancilla(), self.new_ancilla()))
+                return 1
+
+            # Blocked/excluded e.p. post-select on the target
+            if m.move_variant == enums.MoveVariant.EXCLUDED:
+                is_there = self.post_select_on(tqubit)
+                if is_there:
+                    return 0
+                self.add_entangled(tqubit)
+            self.circuit.append(
+                qm.en_passant(squbit, tqubit, epqubit, self.new_ancilla(),
+                              self.new_ancilla()))
+            return 1
+
+        if m.move_type == enums.MoveType.PAWN_CAPTURE:
+            # For pawn capture, first measure source.
+            is_there = self.post_select_on(squbit)
+            if not is_there:
+                return 0
+            if tqubit in self.entangled_squares:
+                old_tqubit = self.unhook(tqubit)
+                self.add_entangled(squbit, tqubit)
+
+                self.circuit.append(
+                    qm.controlled_operation(cirq.ISWAP, [squbit, tqubit],
+                                            [old_tqubit], []))
+            else:
+                # Classical case
+                self.state = set_nth_bit(sbit, self.state, 0)
+                self.state = set_nth_bit(tbit, self.state, 1)
+            return 1
+
+        if m.move_type == enums.MoveType.SPLIT_SLIDE:
+            tbit2 = square_to_bit(m.target2)
+            tqubit2 = bit_to_qubit(tbit2)
+
+            # Find all the squares on both paths
+            path_qubits = self.path_qubits(m.source, m.target)
+            path_qubits2 = self.path_qubits(m.source, m.target2)
+
+            if len(path_qubits) == 0 and len(path_qubits2) == 0:
+                # No interposing squares, just jump.
+                m.move_type = enums.MoveType.SPLIT_JUMP
+            else:
+                self.add_entangled(squbit, tqubit, tqubit2)
+                path1 = self.create_path_ancilla(path_qubits)
+                path2 = self.create_path_ancilla(path_qubits2)
+                ancilla = self.new_ancilla()
+                self.circuit.append(
+                    qm.split_slide(squbit, tqubit, tqubit2, path1, path2,
+                                   ancilla))
+                return 1
+
+        if m.move_type == enums.MoveType.MERGE_SLIDE:
+            sbit2 = square_to_bit(m.source2)
+            squbit2 = bit_to_qubit(sbit2)
+            self.add_entangled(squbit, squbit2, tqubit)
+
+            # Find all the squares on both paths
+            path_qubits = self.path_qubits(m.source, m.target)
+            path_qubits2 = self.path_qubits(m.source2, m.target)
+            if len(path_qubits) == 0 and len(path_qubits2) == 0:
+                # No interposing squares, just jump.
+                m.move_type = enums.MoveType.MERGE_JUMP
+            else:
+                path1 = self.create_path_ancilla(path_qubits)
+                path2 = self.create_path_ancilla(path_qubits2)
+                ancilla = self.new_ancilla()
+                self.circuit.append(
+                    qm.merge_slide(squbit, tqubit, squbit2, path1, path2,
+                                   ancilla))
+                return 1
+
+        if (m.move_type == enums.MoveType.SLIDE or
+                m.move_type == enums.MoveType.PAWN_TWO_STEP):
+            path_qubits = self.path_qubits(m.source, m.target)
+            if len(path_qubits) == 0:
+                # No path, change to jump
+                m.move_type = enums.MoveType.JUMP
+
+        if (m.move_type == enums.MoveType.SLIDE or
+                m.move_type == enums.MoveType.PAWN_TWO_STEP):
+            for p in path_qubits:
+                if (p not in self.entangled_squares and
+                        nth_bit_of(qubit_to_bit(p), self.state)):
+                    # Classical piece in the way
+                    return 0
+
+            # For excluded case, measure target
+            if m.move_variant == enums.MoveVariant.EXCLUDED:
+                is_there = self.post_select_on(tqubit)
+                if is_there:
+                    return 0
+
+            self.add_entangled(squbit, tqubit)
+            if m.move_variant == enums.MoveVariant.CAPTURE:
+                capture_ancilla = self.new_ancilla()
+                self.circuit.append(
+                    qm.controlled_operation(cirq.X, [capture_ancilla], [squbit],
+                                            path_qubits))
+
+                # We need to add the captured_ancilla to entangled squares
+                # So that we measure it
+                self.entangled_squares.add(capture_ancilla)
+                capture_allowed = self.post_select_on(capture_ancilla)
+
+                if not capture_allowed:
+                    return 0
+                else:
+                    # Perform the captured slide
+                    self.add_entangled(squbit)
+                    # Remove the target from the board into an ancilla
+                    # and set bit to zero
+                    self.unhook(tqubit)
+                    self.state = set_nth_bit(tbit, self.state, 0)
+
+                    # Re-add target since we need to swap into the square
+                    self.add_entangled(tqubit)
+
+                    # Perform the actual move
+                    self.circuit.append(qm.normal_move(squbit, tqubit))
+
+                    # Set source to empty
+                    self.unhook(squbit)
+                    self.state = set_nth_bit(sbit, self.state, 0)
+
+                    # Now set the whole path to empty
+                    for p in path_qubits:
+                        self.state = set_nth_bit(qubit_to_bit(p), self.state, 0)
+                        self.unhook(p)
+                    return 1
+            # Basic slide (or successful excluded slide)
+
+            # Add all involved squares into entanglement
+            self.add_entangled(squbit, tqubit, *path_qubits)
+
+            if len(path_qubits) == 1:
+                # For path of one, no ancilla needed
+                self.circuit.append(qm.slide_move(squbit, tqubit, path_qubits))
+                return 1
+            # Longer paths require a path ancilla
+            ancilla = self.new_ancilla()
+            self.circuit.append(
+                qm.slide_move(squbit, tqubit, path_qubits, ancilla))
+            return 1
+
+        if (m.move_type == enums.MoveType.JUMP or
+                m.move_type == enums.MoveType.PAWN_STEP):
+            if (squbit not in self.entangled_squares and
+                    tqubit not in self.entangled_squares):
+                # Classical version
+                self.state = set_nth_bit(sbit, self.state, 0)
+                self.state = set_nth_bit(tbit, self.state, 1)
+                return 1
+
+            # Measure source for capture
+            if m.move_variant == enums.MoveVariant.CAPTURE:
+                is_there = self.post_select_on(squbit)
+                if not is_there:
+                    return 0
+                self.unhook(tqubit)
+
+            # Measure target for excluded
+            if m.move_variant == enums.MoveVariant.EXCLUDED:
+                is_there = self.post_select_on(tqubit)
+                if is_there:
+                    return 0
+
+            # Only convert source qubit to ancilla if target
+            # is empty
+            unhook = tqubit not in self.entangled_squares
+            self.add_entangled(squbit, tqubit)
+
+            # Execute jump
+            self.circuit.append(qm.normal_move(squbit, tqubit))
+
+            if unhook or m.move_variant != enums.MoveVariant.BASIC:
+                # The source is empty.
+                # Change source qubit to be an ancilla
+                # and set classical bit to zero
+                self.state = set_nth_bit(sbit, self.state, 0)
+                self.unhook(squbit)
+
+            return 1
+
+        if m.move_type == enums.MoveType.SPLIT_JUMP:
+            tbit2 = square_to_bit(m.target2)
+            tqubit2 = bit_to_qubit(tbit2)
+            self.add_entangled(squbit, tqubit, tqubit2)
+            self.circuit.append(qm.split_move(squbit, tqubit, tqubit2))
+            self.state = set_nth_bit(sbit, self.state, 0)
+            self.unhook(squbit)
+            return 1
+
+        if m.move_type == enums.MoveType.MERGE_JUMP:
+            sbit2 = square_to_bit(m.source2)
+            squbit2 = bit_to_qubit(sbit2)
+            self.add_entangled(squbit, squbit2, tqubit)
+            self.circuit.append(qm.merge_move(squbit, squbit2, tqubit))
+            # TODO: should the source qubit be 'unhooked'?
+            return 1
+
+        if m.move_type == enums.MoveType.KS_CASTLE:
+            # Figure out the rook squares
+            if sbit == square_to_bit('e1') and tbit == square_to_bit('g1'):
+                rook_sbit = square_to_bit('h1')
+                rook_tbit = square_to_bit('f1')
+            elif sbit == square_to_bit('e8') and tbit == square_to_bit('g8'):
+                rook_sbit = square_to_bit('h8')
+                rook_tbit = square_to_bit('f8')
+            else:
+                raise ValueError(f'Invalid kingside castling move')
+            rook_squbit = bit_to_qubit(rook_sbit)
+            rook_tqubit = bit_to_qubit(rook_tbit)
+
+            # Piece in non-superposition in the way, not legal
+            if (nth_bit_of(rook_tbit, self.state) and
+                    not rook_tqubit in self.entangled_squares):
+                return 0
+            if (nth_bit_of(tbit, self.state) and
+                    not tqubit in self.entangled_squares):
+                return 0
+
+            # Not in superposition, just castle
+            if (rook_tqubit not in self.entangled_squares and
+                    tqubit not in self.entangled_squares):
+                self.set_castle(sbit, rook_sbit, tbit, rook_tbit)
+                return 1
+
+            # Both intervening squares in superposition
+            if (rook_tqubit in self.entangled_squares and
+                    tqubit in self.entangled_squares):
+                castle_ancilla = self.create_path_ancilla([rook_tqubit, tqubit])
+                self.entangled_squares.add(castle_ancilla)
+                castle_allowed = self.post_select_on(castle_ancilla)
+                if castle_allowed:
+                    self.unhook(rook_tqubit)
+                    self.unhook(tqubit)
+                    self.set_castle(sbit, rook_sbit, tbit, rook_tbit)
+                    return 1
+                else:
+                    self.post_selection[castle_ancilla] = castle_allowed
+                    return 0
+
+            # One intervening square in superposition
+            if rook_tqubit in self.entangled_squares:
+                measure_qubit = rook_tqubit
+                measure_bit = rook_tbit
+            else:
+                measure_qubit = tqubit
+                measure_bit = tbit
+            is_there = self.post_select_on(measure_qubit)
+            if is_there:
+                return 0
+            self.set_castle(sbit, rook_sbit, tbit, rook_tbit)
+            return 1
+
+        if m.move_type == enums.MoveType.QS_CASTLE:
+
+            # Figure out the rook squares and the b-file square involved
+            if sbit == square_to_bit('e1') and tbit == square_to_bit('c1'):
+                rook_sbit = square_to_bit('a1')
+                rook_tbit = square_to_bit('d1')
+                b_bit = square_to_bit('b1')
+            elif sbit == square_to_bit('e8') and tbit == square_to_bit('c8'):
+                rook_sbit = square_to_bit('a8')
+                rook_tbit = square_to_bit('d8')
+                b_bit = square_to_bit('b8')
+            else:
+                raise ValueError(f'Invalid queenside castling move')
+            rook_squbit = bit_to_qubit(rook_sbit)
+            rook_tqubit = bit_to_qubit(rook_tbit)
+            b_qubit = bit_to_qubit(b_bit)
+
+            # Piece in non-superposition in the way, not legal
+            if (nth_bit_of(rook_tbit, self.state) and
+                    not rook_tqubit in self.entangled_squares):
+                return 0
+            if (nth_bit_of(tbit, self.state) and
+                    not tqubit in self.entangled_squares):
+                return 0
+            if (b_bit is not None and nth_bit_of(b_bit, self.state) and
+                    not b_qubit in self.entangled_squares):
+                return 0
+
+            # Not in superposition, just castle
+            if (rook_tqubit not in self.entangled_squares and
+                    tqubit not in self.entangled_squares and
+                    b_qubit not in self.entangled_squares):
+                self.set_castle(sbit, rook_sbit, tbit, rook_tbit)
+                return 1
+
+            # Neither intervening squares in superposition
+            if (rook_tqubit not in self.entangled_squares and
+                    tqubit not in self.entangled_squares):
+                if b_qubit not in self.entangled_squares:
+                    self.set_castle(sbit, rook_sbit, tbit, rook_tbit)
+                else:
+                    self.queenside_castle(squbit, rook_squbit, tqubit,
+                                          rook_tqubit, b_qubit)
+                return 1
+
+            # Both intervening squares in superposition
+            if (rook_tqubit in self.entangled_squares and
+                    tqubit in self.entangled_squares):
+                castle_ancilla = self.create_path_ancilla([rook_tqubit, tqubit])
+                self.entangled_squares.add(castle_ancilla)
+                castle_allowed = self.post_select_on(castle_ancilla)
+                if castle_allowed:
+                    self.unhook(rook_tqubit)
+                    self.unhook(tqubit)
+                    if b_qubit not in self.entangled_squares:
+                        self.set_castle(sbit, rook_sbit, tbit, rook_tbit)
+                    else:
+                        self.queenside_castle(squbit, rook_squbit, tqubit,
+                                              rook_tqubit, b_qubit)
+                    return 1
+                else:
+                    self.post_selection[castle_ancilla] = castle_allowed
+                    return 0
+
+            # One intervening square in superposition
+            if rook_tqubit in self.entangled_squares:
+                measure_qubit = rook_tqubit
+                measure_bit = rook_tbit
+            else:
+                measure_qubit = tqubit
+                measure_bit = tbit
+            is_there = self.post_select_on(measure_qubit)
+            if is_there:
+                return 0
+            if b_qubit not in self.entangled_squares:
+                self.set_castle(sbit, rook_sbit, tbit, rook_tbit)
+            else:
+                self.queenside_castle(squbit, rook_squbit, tqubit, rook_tqubit,
+                                      b_qubit)
+            return 1
+
+        raise ValueError(f'Move type {m.move_type} not supported')

--- a/recirq/quantum_chess/quantum_board_test.py
+++ b/recirq/quantum_chess/quantum_board_test.py
@@ -28,7 +28,7 @@ from recirq.quantum_chess.test_utils import (
 )
 
 NOISY_SAMPLER = cirq.DensityMatrixSimulator(noise=ccn.DepolarizingNoiseModel(
-    depol_prob=0.003))
+    depol_prob=0.002))
 
 BIG_CIRQ_BOARDS = (
     qb.CirqBoard(0, error_mitigation=enums.ErrorMitigation.Error),
@@ -45,7 +45,7 @@ ALL_CIRQ_BOARDS = BIG_CIRQ_BOARDS + (
                  sampler=NOISY_SAMPLER,
                  device=cirq.google.Sycamore,
                  error_mitigation=enums.ErrorMitigation.Correct,
-                 noise_mitigation=0.05),
+                 noise_mitigation=0.08),
 )
 
 

--- a/recirq/quantum_chess/quantum_board_test.py
+++ b/recirq/quantum_chess/quantum_board_test.py
@@ -1,0 +1,861 @@
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import cirq
+import cirq.contrib.noise_models as ccn
+
+import recirq.quantum_chess.enums as enums
+import recirq.quantum_chess.move as move
+import recirq.quantum_chess.quantum_board as qb
+import recirq.quantum_chess.bit_utils as u
+from recirq.quantum_chess.test_utils import (
+    assert_sample_distribution,
+    assert_samples_in,
+    assert_this_or_that,
+    assert_prob_about,
+    assert_fifty_fifty,
+)
+
+NOISY_SAMPLER = cirq.DensityMatrixSimulator(noise=ccn.DepolarizingNoiseModel(
+    depol_prob=0.003))
+
+BIG_CIRQ_BOARDS = (
+    qb.CirqBoard(0, error_mitigation=enums.ErrorMitigation.Error),
+    qb.CirqBoard(0,
+                 device=cirq.google.Sycamore,
+                 error_mitigation=enums.ErrorMitigation.Error),
+)
+
+ALL_CIRQ_BOARDS = BIG_CIRQ_BOARDS + (
+    qb.CirqBoard(0,
+                 device=cirq.google.Sycamore23,
+                 error_mitigation=enums.ErrorMitigation.Error),
+    qb.CirqBoard(0,
+                 sampler=NOISY_SAMPLER,
+                 device=cirq.google.Sycamore,
+                 error_mitigation=enums.ErrorMitigation.Correct,
+                 noise_mitigation=0.05),
+)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_initial_state(board):
+    """Tests basic functionality of boards and setting an initial state."""
+    b = board.with_state(u.squares_to_bitboard(['a1', 'b1', 'c1']))
+    samples = b.sample(100)
+    assert len(samples) == 100
+    for x in samples:
+        assert x == 7
+    probs = b.get_probability_distribution(100)
+    assert len(probs) == 64
+    full_squares = b.get_full_squares_bitboard()
+    empty_squares = b.get_empty_squares_bitboard()
+    for bit in range(3):
+        assert qb.nth_bit_of(bit, full_squares)
+        assert not qb.nth_bit_of(bit, empty_squares)
+        assert probs[bit] == 1.0
+    for bit in range(3, 64):
+        assert not qb.nth_bit_of(bit, full_squares)
+        assert qb.nth_bit_of(bit, empty_squares)
+        assert probs[bit] == 0.0
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_classical_jump_move(board):
+    """Tests a jump move in a classical position."""
+    b = board.with_state(u.squares_to_bitboard(['a1', 'c1']))
+    m = move.Move('a1',
+                  'b1',
+                  move_type=enums.MoveType.JUMP,
+                  move_variant=enums.MoveVariant.BASIC)
+    b.do_move(m)
+    assert_samples_in(b, [u.squares_to_bitboard(['b1', 'c1'])])
+
+
+@pytest.mark.parametrize('move_type,board', (
+    *[(enums.MoveType.SPLIT_JUMP, b) for b in ALL_CIRQ_BOARDS],
+    *[(enums.MoveType.SPLIT_SLIDE, b) for b in ALL_CIRQ_BOARDS],
+))
+def test_split_move(move_type, board):
+    b = board.with_state(u.squares_to_bitboard(['a1']))
+    b.do_move(
+        move.Move('a1',
+                  'a3',
+                  target2='c1',
+                  move_type=move_type,
+                  move_variant=enums.MoveVariant.BASIC))
+    samples = b.sample(100)
+    assert_this_or_that(samples, u.squares_to_bitboard(['a3']),
+                        u.squares_to_bitboard(['c1']))
+    probs = b.get_probability_distribution(5000)
+    assert_fifty_fifty(probs, qb.square_to_bit('a3'))
+    assert_fifty_fifty(probs, qb.square_to_bit('c1'))
+
+    # Test doing a jump after a split move
+    m = move.Move('c1',
+                  'd1',
+                  move_type=enums.MoveType.JUMP,
+                  move_variant=enums.MoveVariant.BASIC)
+    did_it_move = b.do_move(m)
+    samples = b.sample(100)
+    assert_this_or_that(samples, u.squares_to_bitboard(['a3']),
+                        u.squares_to_bitboard(['d1']))
+    probs = b.get_probability_distribution(5000)
+    assert_fifty_fifty(probs, u.square_to_bit('a3'))
+    assert_fifty_fifty(probs, u.square_to_bit('d1'))
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_split_and_use_same_square(board):
+    b = board.with_state(u.squares_to_bitboard(['a1']))
+    assert b.perform_moves(
+        'a1a2b1:SPLIT_JUMP:BASIC',
+        'b1b2:JUMP:BASIC',
+        'b2a2:JUMP:BASIC',
+    )
+    probs = b.get_probability_distribution(5000)
+    assert_sample_distribution(b, {
+        u.squares_to_bitboard(['a2']): 1 / 2,
+        u.squares_to_bitboard(['b2']): 1 / 2
+    })
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_exclusion(board):
+    """Splits piece b1 to c1 and d1 then tries a excluded move from a1 to c1."""
+    b = board.with_state(u.squares_to_bitboard(['a1', 'b1']))
+    b.do_move(
+        move.Move('b1',
+                  'c1',
+                  target2='d1',
+                  move_type=enums.MoveType.SPLIT_JUMP,
+                  move_variant=enums.MoveVariant.BASIC))
+    did_it_move = b.do_move(
+        move.Move('a1',
+                  'c1',
+                  move_type=enums.MoveType.JUMP,
+                  move_variant=enums.MoveVariant.EXCLUDED))
+    samples = b.sample(20)
+    if did_it_move:
+        expected = u.squares_to_bitboard(['c1', 'd1'])
+        assert all(sample == expected for sample in samples)
+    else:
+        expected = u.squares_to_bitboard(['a1', 'c1'])
+        assert all(sample == expected for sample in samples)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_capture(board):
+    """Splits piece from b1 to c1 and d1 then attempts a capture on a1."""
+    b = board.with_state(u.squares_to_bitboard(['a1', 'b1']))
+    b.do_move(
+        move.Move('b1',
+                  'c1',
+                  target2='d1',
+                  move_type=enums.MoveType.SPLIT_JUMP,
+                  move_variant=enums.MoveVariant.BASIC))
+    did_it_move = b.do_move(
+        move.Move('c1',
+                  'a1',
+                  move_type=enums.MoveType.JUMP,
+                  move_variant=enums.MoveVariant.CAPTURE))
+    if did_it_move:
+        expected = u.squares_to_bitboard(['a1'])
+    else:
+        expected = u.squares_to_bitboard(['a1', 'd1'])
+    assert_samples_in(b, [expected])
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_merge_move(board):
+    """Splits piece on a1 to b1 and c1 and then merges back to a1."""
+    b = board.with_state(u.squares_to_bitboard(['a1']))
+    b.do_move(
+        move.Move('a1',
+                  'b1',
+                  target2='c1',
+                  move_type=enums.MoveType.SPLIT_JUMP,
+                  move_variant=enums.MoveVariant.BASIC))
+    b.do_move(
+        move.Move('b1',
+                  'a1',
+                  source2='c1',
+                  move_type=enums.MoveType.MERGE_JUMP,
+                  move_variant=enums.MoveVariant.BASIC))
+    assert_samples_in(b, [u.squares_to_bitboard(['a1'])])
+    assert b.get_full_squares_bitboard() == 1
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_simple_slide_move(board):
+    """Tests a basic slide that is totally unblocked."""
+    b = board.with_state(u.squares_to_bitboard(['a1']))
+    b.do_move(
+        move.Move('a1',
+                  'd1',
+                  move_type=enums.MoveType.SLIDE,
+                  move_variant=enums.MoveVariant.BASIC))
+    samples = b.sample(10)
+    assert all(sample == u.squares_to_bitboard(['d1']) for sample in samples)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_blocked_slide_move(board):
+    """Tests a basic slide that is blocked.
+
+    Slide from a1 to d1 is blocked by a piece on b1.
+    """
+    b = board.with_state(u.squares_to_bitboard(['a1', 'b1']))
+    m = move.Move('a1',
+                  'd1',
+                  move_type=enums.MoveType.SLIDE,
+                  move_variant=enums.MoveVariant.BASIC)
+    b.do_move(m)
+    samples = b.sample(10)
+    expected = u.squares_to_bitboard(['a1', 'b1'])
+    assert all(sample == expected for sample in samples)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_blocked_slide_clear(board):
+    """Blocked slide with 100% success
+
+    Tests a piece "blocked" by itself.
+
+    Position: Ra1. Moves: Ra1^a3a4 Ra3a8
+    """
+    b = board.with_state(u.squares_to_bitboard(['a1']))
+    assert b.perform_moves(
+        'a1a3a4:SPLIT_SLIDE:BASIC',
+        'a3a8:SLIDE:BASIC',
+    )
+    print(b.circuit)
+    samples = b.sample(100)
+    possibilities = [
+        u.squares_to_bitboard(['a4']),
+        u.squares_to_bitboard(['a8']),
+    ]
+    assert all(sample in possibilities for sample in samples)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_blocked_slide_blocked(board):
+    """Blocked slide with 0% success
+
+    Position: re5, rf5. Moves: rf5d5
+    """
+    b = board.with_state(u.squares_to_bitboard(['e5', 'f5']))
+    m = move.Move('f5',
+                  'd5',
+                  move_type=enums.MoveType.SLIDE,
+                  move_variant=enums.MoveVariant.BASIC)
+    b.do_move(m)
+    samples = b.sample(100)
+    expected = u.squares_to_bitboard(['e5', 'f5'])
+    assert all(sample == expected for sample in samples)
+
+
+def test_blocked_slide_capture_through():
+    success = 0
+    for trials in range(100):
+        b = qb.CirqBoard(u.squares_to_bitboard(['a8', 'c6']))
+        b.do_move(
+            move.Move('c6',
+                      'b8',
+                      target2='d8',
+                      move_type=enums.MoveType.SPLIT_JUMP,
+                      move_variant=enums.MoveVariant.BASIC))
+        did_it_move = b.do_move(
+            move.Move('a8',
+                      'd8',
+                      move_type=enums.MoveType.SLIDE,
+                      move_variant=enums.MoveVariant.CAPTURE))
+        if did_it_move:
+            success += 1
+    assert success > 25
+    assert success < 75
+
+
+# Works on all boards but is really slow
+@pytest.mark.parametrize('board', BIG_CIRQ_BOARDS)
+def test_superposition_slide_move(board):
+    """Tests a basic slide through a superposition.
+
+    Sets up superposition of c1 and f1 with a slide from a1 to d1.
+
+    Valid end state should be a1 and c1 (blocked), state = 5, or
+    d1 and f1 (unblocked), state = 40.
+    """
+    b = board.with_state(u.squares_to_bitboard(['a1', 'e1']))
+    b.do_move(
+        move.Move('e1',
+                  'f1',
+                  target2='c1',
+                  move_type=enums.MoveType.SPLIT_JUMP,
+                  move_variant=enums.MoveVariant.BASIC))
+    b.do_move(
+        move.Move('a1',
+                  'd1',
+                  move_type=enums.MoveType.SLIDE,
+                  move_variant=enums.MoveVariant.BASIC))
+    blocked = u.squares_to_bitboard(['a1', 'c1'])
+    moved = u.squares_to_bitboard(['d1', 'f1'])
+    assert_samples_in(b, [blocked, moved])
+    probs = b.get_probability_distribution(5000)
+    assert_fifty_fifty(probs, 0)
+    assert_fifty_fifty(probs, 2)
+    assert_fifty_fifty(probs, 3)
+    assert_fifty_fifty(probs, 5)
+
+
+@pytest.mark.parametrize('board', BIG_CIRQ_BOARDS)
+def test_superposition_slide_move2(board):
+    """Tests a basic slide through a superposition of two pieces.
+
+    Splits b3 and c3 to b2/b1 and c2/c1 then slides a1 to d1.
+    """
+    b = board.with_state(u.squares_to_bitboard(['a1', 'b3', 'c3']))
+    assert b.perform_moves(
+        'b3b2b1:SPLIT_JUMP:BASIC',
+        'c3c2c1:SPLIT_JUMP:BASIC',
+        'a1e1:SLIDE:BASIC',
+    )
+    possibilities = [
+        u.squares_to_bitboard(['a1', 'b1', 'c1']),
+        u.squares_to_bitboard(['a1', 'b1', 'c2']),
+        u.squares_to_bitboard(['a1', 'b2', 'c1']),
+        u.squares_to_bitboard(['e1', 'b2', 'c2'])
+    ]
+    samples = b.sample(100)
+    assert (all(sample in possibilities for sample in samples))
+    probs = b.get_probability_distribution(10000)
+    assert_fifty_fifty(probs, u.square_to_bit('b2'))
+    assert_fifty_fifty(probs, u.square_to_bit('b1'))
+    assert_fifty_fifty(probs, u.square_to_bit('c2'))
+    assert_fifty_fifty(probs, u.square_to_bit('c1'))
+    assert_prob_about(probs, u.square_to_bit('a1'), 0.75)
+    assert_prob_about(probs, u.square_to_bit('e1'), 0.25)
+
+
+@pytest.mark.parametrize('board', BIG_CIRQ_BOARDS)
+def test_excluded_slide(board):
+    """Test excluded slide.
+
+    Slides from a1 to c1.  b1 will block path in superposition
+    and c1 will be blocked/excluded in superposition.
+    """
+    b = board.with_state(u.squares_to_bitboard(['a1', 'b2', 'c2']))
+    did_it_move = b.perform_moves(
+        'b2b1a2:SPLIT_JUMP:BASIC',
+        'c2c1d2:SPLIT_JUMP:BASIC',
+        'a1c1:SLIDE:EXCLUDED',
+    )
+    samples = b.sample(100)
+
+    if did_it_move:
+        possibilities = [
+            u.squares_to_bitboard(['c1', 'a2', 'd2']),
+            u.squares_to_bitboard(['a1', 'b1', 'd2']),
+        ]
+        assert (all(sample in possibilities for sample in samples))
+    else:
+        possibilities = [
+            u.squares_to_bitboard(['a1', 'b1', 'c1']),
+            u.squares_to_bitboard(['a1', 'a2', 'c1']),
+        ]
+        assert (all(sample in possibilities for sample in samples))
+
+
+@pytest.mark.parametrize('board', BIG_CIRQ_BOARDS)
+def test_capture_slide(board):
+    """Tests a capture slide move.
+
+    Splits from a1 to b1/c1 then tries to capture a piece on c3.
+    Will test most cases, since c1, c2, and c3 will all be in
+    superposition.
+    """
+    b = board.with_state(u.squares_to_bitboard(['a1', 'a2', 'a3']))
+    did_it_move = b.perform_moves(
+        'a1b1c1:SPLIT_JUMP:BASIC',
+        'a2b2c2:SPLIT_JUMP:BASIC',
+        'a3b3c3:SPLIT_JUMP:BASIC',
+        'c1c3:SLIDE:CAPTURE',
+    )
+    samples = b.sample(1000)
+    if did_it_move:
+        possibilities = [
+            u.squares_to_bitboard(['c3', 'b2']),
+            u.squares_to_bitboard(['c3', 'b2', 'b3']),
+        ]
+        assert (all(sample in possibilities for sample in samples))
+    else:
+        possibilities = [
+            u.squares_to_bitboard(['c1', 'c2', 'b3']),
+            u.squares_to_bitboard(['c1', 'c2', 'c3']),
+            u.squares_to_bitboard(['b1', 'b2', 'b3']),
+            u.squares_to_bitboard(['b1', 'b2', 'c3']),
+            u.squares_to_bitboard(['b1', 'c2', 'b3']),
+            u.squares_to_bitboard(['b1', 'c2', 'c3']),
+        ]
+        assert (all(sample in possibilities for sample in samples))
+
+
+@pytest.mark.parametrize('board', BIG_CIRQ_BOARDS)
+def test_split_one_slide(board):
+    """Tests a split slide with one blocked path.
+
+    a1 will split to a3 and c1 with square a2 blocked in superposition.
+    """
+    b = board.with_state(u.squares_to_bitboard(['a1', 'b2']))
+    assert b.perform_moves(
+        'b2a2c2:SPLIT_JUMP:BASIC',
+        'a1a3c1:SPLIT_SLIDE:BASIC',
+    )
+    samples = b.sample(100)
+    possibilities = [
+        u.squares_to_bitboard(['c1', 'a2']),
+        u.squares_to_bitboard(['a3', 'c2']),
+        u.squares_to_bitboard(['c1', 'c2']),
+    ]
+    assert (all(sample in possibilities for sample in samples))
+    probs = b.get_probability_distribution(10000)
+    assert_fifty_fifty(probs, qb.square_to_bit('a2'))
+    assert_fifty_fifty(probs, qb.square_to_bit('c2'))
+    assert_prob_about(probs, qb.square_to_bit('a3'), 0.25)
+    assert_prob_about(probs, qb.square_to_bit('c1'), 0.75)
+
+
+@pytest.mark.parametrize('board', BIG_CIRQ_BOARDS)
+def test_split_both_sides(board):
+    """ Tests a split slide move where both paths of the slide
+    are blocked in superposition.
+
+    The piece will split from a1 to a5/e1.
+    The squares c1 and d1 will block one side of the path in superposition.
+    The square a3 will be blocked on the other path.
+
+    This will create a lop-sided distribution to test multi-square paths.
+    """
+    b = board.with_state(u.squares_to_bitboard(['a1', 'b3', 'c3', 'd3']))
+    assert b.perform_moves(
+        'b3a3b4:SPLIT_JUMP:BASIC',
+        'c3c2c1:SPLIT_JUMP:BASIC',
+        'd3d2d1:SPLIT_JUMP:BASIC',
+        'a1a5e1:SPLIT_SLIDE:BASIC',
+    )
+    samples = b.sample(1000)
+    assert len(samples) == 1000
+    possibilities = [
+        #                 a1/a5/e1 a3/b4 c1/c2 d1/d2
+        u.squares_to_bitboard(['a1', 'a3', 'c1', 'd1']),
+        u.squares_to_bitboard(['a1', 'a3', 'c1', 'd2']),
+        u.squares_to_bitboard(['a1', 'a3', 'c2', 'd1']),
+        u.squares_to_bitboard(['e1', 'a3', 'c2', 'd2']),
+        u.squares_to_bitboard(['a5', 'b4', 'c1', 'd1']),
+        u.squares_to_bitboard(['a5', 'b4', 'c1', 'd2']),
+        u.squares_to_bitboard(['a5', 'b4', 'c2', 'd1']),
+        u.squares_to_bitboard(['a5', 'b4', 'c2', 'd2']),
+        u.squares_to_bitboard(['e1', 'b4', 'c2', 'd2']),
+    ]
+    assert (all(sample in possibilities for sample in samples))
+    probs = b.get_probability_distribution(25000)
+    assert_fifty_fifty(probs, qb.square_to_bit('a3'))
+    assert_fifty_fifty(probs, qb.square_to_bit('b4'))
+    assert_fifty_fifty(probs, qb.square_to_bit('c1'))
+    assert_fifty_fifty(probs, qb.square_to_bit('c2'))
+    assert_fifty_fifty(probs, qb.square_to_bit('d1'))
+    assert_fifty_fifty(probs, qb.square_to_bit('d2'))
+    assert_prob_about(probs, qb.square_to_bit('a1'), 0.375)
+    assert_prob_about(probs, qb.square_to_bit('e1'), 0.1875)
+    assert_prob_about(probs, qb.square_to_bit('a5'), 0.4375)
+
+
+@pytest.mark.parametrize('board', BIG_CIRQ_BOARDS)
+def test_merge_slide_one_side(board):
+    """Tests merge slide.
+
+    Splits a1 to a4 and d1 and then merges to d4.
+    The square c4 will block one path of the merge in superposition.
+    """
+    b = board.with_state(u.squares_to_bitboard(['a1', 'c3']))
+    assert b.perform_moves(
+        'a1a4d1:SPLIT_SLIDE:BASIC',
+        'c3c4c5:SPLIT_JUMP:BASIC',
+        'a4d4--d1:MERGE_SLIDE:BASIC',
+    )
+    possibilities = [
+        u.squares_to_bitboard(['a4', 'c4']),
+        u.squares_to_bitboard(['d4', 'c4']),
+        u.squares_to_bitboard(['d4', 'c5']),
+    ]
+    assert_samples_in(b, possibilities)
+    probs = b.get_probability_distribution(20000)
+    assert_fifty_fifty(probs, qb.square_to_bit('c4'))
+    assert_fifty_fifty(probs, qb.square_to_bit('c5'))
+    assert_prob_about(probs, qb.square_to_bit('a4'), 0.25)
+    assert_prob_about(probs, qb.square_to_bit('d4'), 0.75)
+
+
+@pytest.mark.parametrize('board', BIG_CIRQ_BOARDS)
+def test_merge_slide_both_side(board):
+    """Tests a merge slide where both paths are blocked.
+
+    Splits a1 to a4/d1 and merges back to d4. c4 and d3 will
+    block one square on each path.
+    """
+    b = board.with_state(u.squares_to_bitboard(['a1', 'c2', 'c3']))
+    assert b.perform_moves(
+        'a1a4d1:SPLIT_SLIDE:BASIC',
+        'c3c4c5:SPLIT_JUMP:BASIC',
+        'c2d2e2:SPLIT_JUMP:BASIC',
+        'a4d4--d1:MERGE_SLIDE:BASIC',
+    )
+    possibilities = [
+        u.squares_to_bitboard(['a4', 'd2', 'c4']),
+        u.squares_to_bitboard(['d1', 'd2', 'c4']),
+        u.squares_to_bitboard(['a4', 'e2', 'c4']),
+        u.squares_to_bitboard(['d4', 'e2', 'c4']),
+        u.squares_to_bitboard(['d1', 'd2', 'c5']),
+        u.squares_to_bitboard(['d4', 'd2', 'c5']),
+        u.squares_to_bitboard(['d4', 'e2', 'c5']),
+    ]
+    assert_samples_in(b, possibilities)
+    probs = b.get_probability_distribution(20000)
+    assert_fifty_fifty(probs, qb.square_to_bit('c4'))
+    assert_fifty_fifty(probs, qb.square_to_bit('c5'))
+    assert_fifty_fifty(probs, qb.square_to_bit('d2'))
+    assert_fifty_fifty(probs, qb.square_to_bit('e2'))
+    assert_fifty_fifty(probs, qb.square_to_bit('d4'))
+    assert_prob_about(probs, qb.square_to_bit('a4'), 0.25)
+    assert_prob_about(probs, qb.square_to_bit('d1'), 0.25)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_unentangled_pawn_capture(board):
+    """Classical pawn capture."""
+    b = board.with_state(u.squares_to_bitboard(['a4', 'b3', 'c3']))
+    m = move.Move('b3',
+                  'a4',
+                  move_type=enums.MoveType.PAWN_CAPTURE,
+                  move_variant=enums.MoveVariant.BASIC)
+    assert b.do_move(m)
+    assert_samples_in(b, [u.squares_to_bitboard(['a4', 'c3'])])
+
+
+@pytest.mark.parametrize('board', BIG_CIRQ_BOARDS)
+def test_pawn_capture(board):
+    """Tests pawn capture with entanglement.
+
+    Rook on a3 => a4/a5 and rook on c3 => c4/c5.
+    Pawn on b3 attempts to capture both rooks.
+    The first capture should put the pawn in super-position,
+    and the second should force a measurement.
+    """
+    b = board.with_state(u.squares_to_bitboard(['a3', 'b3', 'c3']))
+    # Capture and put the pawn in superposition
+    assert b.perform_moves('a3a4a5:SPLIT_JUMP:BASIC', 'b3a4:PAWN_CAPTURE:BASIC')
+    possibilities = [
+        u.squares_to_bitboard(['a5', 'b3', 'c3']),
+        u.squares_to_bitboard(['a4', 'c3']),
+    ]
+    assert_samples_in(b, possibilities)
+    probs = b.get_probability_distribution(5000)
+    assert_fifty_fifty(probs, qb.square_to_bit('a5'))
+    assert_fifty_fifty(probs, qb.square_to_bit('a4'))
+    assert_fifty_fifty(probs, qb.square_to_bit('b3'))
+
+    did_it_move = b.perform_moves('c3c4c5:SPLIT_JUMP:BASIC',
+                                  'b3c4:PAWN_CAPTURE:BASIC')
+    if did_it_move:
+        possibilities = [
+            u.squares_to_bitboard(['a5', 'b3', 'c5']),
+            u.squares_to_bitboard(['a5', 'c4']),
+        ]
+    else:
+        possibilities = [
+            u.squares_to_bitboard(['a4', 'c4']),
+            u.squares_to_bitboard(['a4', 'c5']),
+        ]
+    assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('initial_board,source,target', (
+    (u.squares_to_bitboard(['e1', 'f1', 'h1']), 'e1', 'g1'),
+    (u.squares_to_bitboard(['e1', 'g1', 'h1']), 'e1', 'g1'),
+    (u.squares_to_bitboard(['e1', 'f1', 'g1', 'h1']), 'e1', 'g1'),
+    (u.squares_to_bitboard(['e8', 'f8', 'h8']), 'e8', 'g8'),
+    (u.squares_to_bitboard(['e8', 'g8', 'h8']), 'e8', 'g8'),
+    (u.squares_to_bitboard(['e8', 'f8', 'g8', 'h8']), 'e8', 'g8'),
+    (u.squares_to_bitboard(['e1', 'c1', 'a1']), 'e1', 'c1'),
+    (u.squares_to_bitboard(['e1', 'd1', 'a1']), 'e1', 'c1'),
+    (u.squares_to_bitboard(['e1', 'c1', 'd1', 'a1']), 'e1', 'c1'),
+))
+def test_illegal_castle(initial_board, source, target):
+    """Tests various combinations of illegal capture.
+
+    Args:
+        initial_board: bitboard to set up
+        source: king to move (should be e1 or e8)
+        target: square to move king to.
+    """
+    b = qb.CirqBoard(initial_board)
+    if target in ['g1', 'g8']:
+        move_type = move_type = enums.MoveType.KS_CASTLE
+    else:
+        move_type = move_type = enums.MoveType.QS_CASTLE
+    m = move.Move(source,
+                  target,
+                  move_type=move_type,
+                  move_variant=enums.MoveVariant.BASIC)
+    assert not b.do_move(m)
+    assert_samples_in(b, [initial_board])
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_unblocked_black_castle(board):
+    """Tests classical kingside black castling move."""
+    b = board.with_state(u.squares_to_bitboard(['e8', 'h8']))
+    m = move.Move('e8',
+                  'g8',
+                  move_type=enums.MoveType.KS_CASTLE,
+                  move_variant=enums.MoveVariant.BASIC)
+    assert b.do_move(m)
+    assert_samples_in(b, [u.squares_to_bitboard(['f8', 'g8'])])
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_unblocked_white_castle(board):
+    """Tests classical kingside white castling move."""
+    b = board.with_state(u.squares_to_bitboard(['e1', 'h1']))
+    m = move.Move('e1',
+                  'g1',
+                  move_type=enums.MoveType.KS_CASTLE,
+                  move_variant=enums.MoveVariant.BASIC)
+    assert b.do_move(m)
+    assert_samples_in(b, [u.squares_to_bitboard(['f1', 'g1'])])
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_unblocked_whitequeenside_castle(board):
+    """Tests classical queenside white castling move."""
+    b = board.with_state(u.squares_to_bitboard(['e1', 'a1']))
+    m = move.Move('e1',
+                  'c1',
+                  move_type=enums.MoveType.QS_CASTLE,
+                  move_variant=enums.MoveVariant.BASIC)
+    assert b.do_move(m)
+    assert_samples_in(b, [u.squares_to_bitboard(['d1', 'c1'])])
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_unblocked_blackqueenside_castle(board):
+    """Tests classical queenside black castling move."""
+    b = board.with_state(u.squares_to_bitboard(['e8', 'a8']))
+    m = move.Move('e8',
+                  'c8',
+                  move_type=enums.MoveType.QS_CASTLE,
+                  move_variant=enums.MoveVariant.BASIC)
+    assert b.do_move(m)
+    assert_samples_in(b, [u.squares_to_bitboard(['d8', 'c8'])])
+
+
+@pytest.mark.parametrize('board', BIG_CIRQ_BOARDS)
+def test_2block_ks_castle(board):
+    """Kingside castling move blocked by 2 pieces in superposition."""
+    b = board.with_state(u.squares_to_bitboard(['e8', 'f6', 'g6', 'h8']))
+    did_it_move = b.perform_moves(
+        'f6f7f8:SPLIT_JUMP:BASIC',
+        'g6g7g8:SPLIT_JUMP:BASIC',
+        'e8g8:KS_CASTLE:BASIC',
+    )
+    if did_it_move:
+        possibilities = [u.squares_to_bitboard(['g8', 'f7', 'g7', 'f8'])]
+    else:
+        possibilities = [
+            u.squares_to_bitboard(['e8', 'f8', 'g7', 'h8']),
+            u.squares_to_bitboard(['e8', 'f7', 'g8', 'h8']),
+            u.squares_to_bitboard(['e8', 'f8', 'g8', 'h8']),
+        ]
+    assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_1block_ks_castle(board):
+    """Kingside castling move blocked by 1 piece in superposition."""
+    b = board.with_state(u.squares_to_bitboard(['e1', 'f3', 'h1']))
+    b.do_move(
+        move.Move('f3',
+                  'f2',
+                  target2='f1',
+                  move_type=enums.MoveType.SPLIT_JUMP,
+                  move_variant=enums.MoveVariant.BASIC))
+    did_it_move = b.do_move(
+        move.Move('e1',
+                  'g1',
+                  move_type=enums.MoveType.KS_CASTLE,
+                  move_variant=enums.MoveVariant.BASIC))
+    if did_it_move:
+        expected = u.squares_to_bitboard(['f1', 'f2', 'g1'])
+    else:
+        expected = u.squares_to_bitboard(['e1', 'f1', 'h1'])
+    assert_samples_in(b, [expected])
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_entangled_qs_castle(board):
+    """Queenside castling move with b-square blocked by superposition.
+
+    This should entangle the castling rook/king with the piece.
+    """
+    b = board.with_state(u.squares_to_bitboard(['e1', 'b3', 'a1']))
+    b.do_move(
+        move.Move('b3',
+                  'b2',
+                  target2='b1',
+                  move_type=enums.MoveType.SPLIT_SLIDE,
+                  move_variant=enums.MoveVariant.BASIC))
+    assert b.do_move(
+        move.Move('e1',
+                  'c1',
+                  move_type=enums.MoveType.QS_CASTLE,
+                  move_variant=enums.MoveVariant.BASIC))
+    possibilities = [
+        u.squares_to_bitboard(['a1', 'b1', 'e1']),
+        u.squares_to_bitboard(['c1', 'b2', 'd1'])
+    ]
+    assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('board', BIG_CIRQ_BOARDS)
+def test_entangled_qs_castle2(board):
+    """Queenside castling move with all intervening squares blocked."""
+    b = board.with_state(u.squares_to_bitboard(['e1', 'b3', 'c3', 'd3', 'a1']))
+    did_it_move = b.perform_moves(
+        'b3b2b1:SPLIT_JUMP:BASIC',
+        'c3c2c1:SPLIT_JUMP:BASIC',
+        'd3d2d1:SPLIT_JUMP:BASIC',
+        'e1c1:QS_CASTLE:BASIC',
+    )
+    if did_it_move:
+        possibilities = [
+            u.squares_to_bitboard(['a1', 'b1', 'e1', 'c2', 'd2']),
+            u.squares_to_bitboard(['c1', 'b2', 'd1', 'c2', 'd2']),
+        ]
+    else:
+        possibilities = [
+            u.squares_to_bitboard(['a1', 'b1', 'e1', 'c1', 'd2']),
+            u.squares_to_bitboard(['a1', 'b2', 'e1', 'c1', 'd2']),
+            u.squares_to_bitboard(['a1', 'b1', 'e1', 'c2', 'd1']),
+            u.squares_to_bitboard(['a1', 'b2', 'e1', 'c2', 'd1']),
+            u.squares_to_bitboard(['a1', 'b1', 'e1', 'c1', 'd1']),
+            u.squares_to_bitboard(['a1', 'b2', 'e1', 'c1', 'd1']),
+        ]
+    assert_samples_in(b, possibilities)
+
+
+@pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
+def test_classical_ep(board):
+    """Fully classical en passant."""
+    b = board.with_state(u.squares_to_bitboard(['e5', 'd5']))
+    m = move.Move('e5',
+                  'd6',
+                  move_type=enums.MoveType.PAWN_EP,
+                  move_variant=enums.MoveVariant.BASIC)
+    b.do_move(m)
+    assert_samples_in(b, [u.squares_to_bitboard(['d6'])])
+
+
+# Seems to be problematic on real device
+def test_capture_ep():
+    """Tests capture en passant.
+
+    Splits b8 to a6/c6.  Capture a6 with b5 pawn to put the source pawn
+    into superposition.  Then move c6 out of the way.
+
+    Finally, move c7 to c5 and perform en passant on b6.
+    """
+    b = qb.CirqBoard(u.squares_to_bitboard(['b8', 'b5', 'c7']))
+    did_it_move = b.perform_moves(
+        'b8a6c6:SPLIT_JUMP:BASIC',
+        'b5a6:PAWN_CAPTURE:BASIC',
+        'c7c5:PAWN_TWO_STEP:BASIC',
+        'b5c6:PAWN_EP:CAPTURE',
+    )
+    if did_it_move:
+        expected = u.squares_to_bitboard(['c6', 'c7'])
+    else:
+        expected = u.squares_to_bitboard(['a6', 'c5'])
+    assert_samples_in(b, [expected])
+
+
+def test_capture_ep2():
+    """Tests capture en passant.
+
+    Splits b8 to a6/c6.  Capture a6 with b5 pawn to put the source pawn
+    into superposition.
+
+    Finally, move c7 to c5 and perform en passant on b6.  This should
+    either capture the knight or the pawn.
+    """
+    b = qb.CirqBoard(u.squares_to_bitboard(['b8', 'b5', 'c7']))
+    did_it_move = b.perform_moves(
+        'b8a6c6:SPLIT_JUMP:BASIC',
+        'c7c5:PAWN_TWO_STEP:BASIC',
+        'b5c6:PAWN_EP:CAPTURE',
+    )
+    assert did_it_move
+    possibilities = [
+        u.squares_to_bitboard(['c6', 'c7']),
+        u.squares_to_bitboard(['c6', 'a6']),
+    ]
+    assert_samples_in(b, possibilities)
+
+
+def test_blocked_ep():
+    """Tests blocked en passant.
+
+    Splits c4 to b6 and d6.  Moves a pawn through the piece on d6.
+    Attempts to en passant the d-pawn using blocked e.p.
+    """
+    b = qb.CirqBoard(u.squares_to_bitboard(['c4', 'c5', 'd7']))
+    did_it_move = b.perform_moves(
+        'c4d6b6:SPLIT_JUMP:BASIC',
+        'd7d5:PAWN_TWO_STEP:BASIC',
+        'c5d6:PAWN_EP:EXCLUDED',
+    )
+    if did_it_move:
+        possibilities = [
+            u.squares_to_bitboard(['b6', 'd6']),
+        ]
+    else:
+        possibilities = [
+            u.squares_to_bitboard(['c5', 'd6', 'd7']),
+        ]
+    assert_samples_in(b, possibilities)
+
+
+def test_basic_ep():
+    b = qb.CirqBoard(u.squares_to_bitboard(['b8', 'b5', 'c7']))
+    assert b.perform_moves(
+        'b8a6c6:SPLIT_JUMP:BASIC',
+        'b5a6:PAWN_CAPTURE:BASIC',
+        'c6b8:JUMP:BASIC',
+        'c7c5:PAWN_TWO_STEP:BASIC',
+        'b5c6:PAWN_EP:BASIC',
+    )
+    possibilities = [
+        u.squares_to_bitboard(['b8', 'c6']),
+        u.squares_to_bitboard(['a6', 'c5']),
+    ]
+    assert_samples_in(b, possibilities)

--- a/recirq/quantum_chess/quantum_moves.py
+++ b/recirq/quantum_chess/quantum_moves.py
@@ -1,0 +1,191 @@
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Quantum Circuits for common quantum chess moves."""
+from typing import List
+
+import cirq
+
+
+def normal_move(s: cirq.Qid, t: cirq.Qid):
+    """ A normal move in quantum chess.
+
+  This function takes two qubits and returns a generator
+  that performs a normal move that moves a piece from the
+  source square to the target square.
+
+  Args:
+    s: source qubit (square where piece starts)
+    t: target qubit (square to move piece to)
+  """
+    yield cirq.ISWAP(s, t)**0.5
+    yield cirq.ISWAP(s, t)**0.5
+
+
+def split_move(s: cirq.Qid, t1: cirq.Qid, t2: cirq.Qid):
+    """ A Split move in quantum chess.
+
+    This function takes three qubits and returns a generator
+    that performs a split move from the source qubit to the
+    two target qubits.
+
+    Args:
+      s: source qubit (square where piece starts)
+      t1: target qubit (first square to move piece to)
+      t2: target qubit (second square to move piece to)
+    """
+    yield cirq.ISWAP(s, t1)**0.5
+    yield cirq.ISWAP(s, t2)**0.5
+    yield cirq.ISWAP(s, t2)**0.5
+
+
+def merge_move(s1: cirq.Qid, s2: cirq.Qid, t: cirq.Qid):
+    """ A Split move in quantum chess.
+
+    This function takes three qubits and returns a generator
+    that performs a split move from the source qubit to the
+    two target qubits.
+
+    Args:
+      s: source qubit (square where piece starts)
+      t1: target qubit (first square to move piece to)
+      t2: target qubit (second square to move piece to)
+    """
+    yield cirq.ISWAP(s1, t)**-0.5
+    yield cirq.ISWAP(s1, t)**-0.5
+    yield cirq.ISWAP(s2, t)**-0.5
+
+
+def slide_move(s: cirq.Qid,
+               t: cirq.Qid,
+               path: List[cirq.Qid],
+               ancilla: cirq.Qid = None):
+    """A Slide move in quantum chess.
+
+    This function takes three qubits and returns a generator
+    that performs a slide move.  This will move a piece
+    from the source to the target controlled by the path qubit.
+    The move will only occur if the path qubit is turned on.
+
+    Args:
+      s: source qubit (square where piece starts)
+      t: target qubit (square to move piece to)
+      p: qubit blocked the path
+    """
+    if len(path) == 0:
+        return normal_move(s, t)
+    if len(path) == 1:
+        p = path[0]
+        yield cirq.X(p)
+        yield cirq.ISWAP(s, t).controlled_by(p)
+        yield cirq.X(p)
+        return
+    if ancilla is None:
+        raise ValueError('Must specify ancilla for path greater than 1.')
+    for p in path:
+        yield cirq.X(p)
+    yield cirq.X(ancilla).controlled_by(*path)
+    for p in path:
+        yield cirq.X(p)
+    yield cirq.ISWAP(s, t).controlled_by(ancilla)
+
+
+def place_piece(s: cirq.Qid):
+    """Place a piece on the board.
+
+    This is not actually a move.  However, since qubits in Cirq
+    default to starting in the |0> state, we will need to activate
+    the qubit by applying an X gate to initialize the position.
+    """
+    yield cirq.X(s)
+
+
+def controlled_operation(gate, qubits, path_qubits, anti_qubits):
+    for p in anti_qubits:
+        yield cirq.X(p)
+    yield gate.on(*qubits).controlled_by(*path_qubits, *anti_qubits)
+    for p in anti_qubits:
+        yield cirq.X(p)
+
+
+def queenside_castle(squbit, rook_squbit, tqubit, rook_tqubit, b_qubit):
+    yield cirq.X(b_qubit)
+    yield cirq.ISWAP(rook_squbit, rook_tqubit).controlled_by(b_qubit)
+    yield cirq.ISWAP(squbit, tqubit).controlled_by(b_qubit)
+    yield cirq.X(b_qubit)
+
+
+def split_slide(squbit, tqubit, tqubit2, path1, path2, ancilla):
+    """Performs a split slide from squbit to two target qubits.
+
+    2 path qubits are needed as controls.  An additional ancilla
+    is needed to transform the double controlled iSWAPs into
+    single controlled iSWAPs.
+    """
+    # Set up the ancilla which will act as a control
+    # This essentially takes ISWAP.controlled_by(path1, path2)
+    # and turns it into ISWAP.controlled_by(ancilla)
+    yield cirq.X(ancilla).controlled_by(path2, path1)
+
+    yield (cirq.ISWAP(squbit, tqubit)**0.5).controlled_by(ancilla)
+    yield (cirq.ISWAP(squbit, tqubit2)).controlled_by(ancilla)
+
+    # Now switch to anti-control of path1
+    yield cirq.X(ancilla).controlled_by(path1)
+
+    yield cirq.ISWAP(squbit, tqubit).controlled_by(ancilla)
+
+    # Switch to control of path1 but anti-control of path2
+    yield cirq.X(ancilla).controlled_by(path1)
+
+    # In order to prevent path2 from needing connectivity to
+    # the ancilla qubit, swap path1 and path.
+    # Then do a CNOT on ancilla with the swapped "path2"
+    yield cirq.SWAP(path1, path2)
+    yield cirq.X(ancilla).controlled_by(path1)
+
+    yield cirq.ISWAP(squbit, tqubit2).controlled_by(ancilla)
+
+
+def merge_slide(squbit, tqubit, squbit2, path1, path2, ancilla):
+    yield cirq.X(ancilla).controlled_by(path1, path2)
+
+    yield (cirq.ISWAP(squbit, tqubit)**-1.0).controlled_by(ancilla)
+    yield (cirq.ISWAP(squbit2, tqubit)**-0.5).controlled_by(ancilla)
+
+    # Now switch to anti-control of path1
+    yield cirq.X(ancilla).controlled_by(path2)
+    yield cirq.ISWAP(squbit2, tqubit).controlled_by(ancilla)
+    # Switch to control of path1 but anti-control of path2
+    yield cirq.X(ancilla).controlled_by(path2)
+
+    # In order to prevent path2 from needing connectivity to
+    # the ancilla qubit, swap path1 and path.
+    # Then do a CNOT on ancilla with the swapped "path2"
+    yield cirq.SWAP(path2, path1)
+    yield cirq.X(ancilla).controlled_by(path2)
+    yield cirq.ISWAP(squbit, tqubit).controlled_by(ancilla)
+
+
+def en_passant(squbit, tqubit, epqubit, path, c):
+    yield cirq.X(path).controlled_by(squbit, epqubit)
+    yield cirq.ISWAP(epqubit, c).controlled_by(path)
+    yield cirq.ISWAP(squbit, tqubit).controlled_by(path)
+
+
+def capture_ep(squbit, tqubit, epqubit, path, c, c2):
+    yield cirq.CNOT(epqubit, path)
+    yield cirq.CNOT(tqubit, path)
+    yield cirq.ISWAP(epqubit, c).controlled_by(path)
+    yield cirq.ISWAP(tqubit, c2).controlled_by(path)
+    yield cirq.ISWAP(squbit, tqubit).controlled_by(path)

--- a/recirq/quantum_chess/quantum_moves_test.py
+++ b/recirq/quantum_chess/quantum_moves_test.py
@@ -1,0 +1,74 @@
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+import cirq
+
+import recirq.quantum_chess.quantum_moves as qm
+
+
+def test_merge():
+    """Tests Merge jump with eqs 11a-f in quantum chess paper."""
+    s = cirq.Simulator()
+    isqrt2 = 1 / np.sqrt(2)
+    s1, s2, t = cirq.LineQubit.range(3)
+
+    # Merge |001> = −i|100>
+    c = cirq.Circuit(cirq.X(t), qm.merge_move(s1, s2, t))
+    expected = [0, 0, 0, 0, -1j, 0, 0, 0]
+    actual = s.simulate(c).state_vector()
+    np.testing.assert_almost_equal(actual, expected)
+
+    # Merge |010> = -1/√2 (i|001> −  |010>)
+    c = cirq.Circuit(cirq.X(s2), qm.merge_move(s1, s2, t))
+    expected = [0, isqrt2 * -1j, isqrt2, 0, 0, 0, 0, 0]
+    actual = s.simulate(c).state_vector()
+    np.testing.assert_almost_equal(actual, expected)
+
+    # Merge |100> = -1/√2 (i|001> +  |010>)
+    c = cirq.Circuit(cirq.X(s1), qm.merge_move(s1, s2, t))
+    expected = [0, isqrt2 * -1j, -1 * isqrt2, 0, 0, 0, 0, 0]
+    actual = s.simulate(c).state_vector()
+    np.testing.assert_almost_equal(actual, expected)
+
+    # Merge |011> = -1/√2 ( |101> + i|110>)
+    c = cirq.Circuit(cirq.X(s2), cirq.X(t), qm.merge_move(s1, s2, t))
+    expected = [0, 0, 0, 0, 0, -1 * isqrt2, -1j * isqrt2, 0]
+    actual = s.simulate(c).state_vector()
+    np.testing.assert_almost_equal(actual, expected)
+
+    # Merge |101> = -i/√2 (i|101> +  |110>)
+    c = cirq.Circuit(cirq.X(s1), cirq.X(t), qm.merge_move(s1, s2, t))
+    expected = [0, 0, 0, 0, 0, isqrt2, -1j * isqrt2, 0]
+    actual = s.simulate(c).state_vector()
+    np.testing.assert_almost_equal(actual, expected)
+
+    # Merge |110> = −i|011>
+    c = cirq.Circuit(cirq.X(s1), cirq.X(s2), qm.merge_move(s1, s2, t))
+    expected = [0, 0, 0, -1j, 0, 0, 0, 0]
+    actual = s.simulate(c).state_vector()
+    np.testing.assert_almost_equal(actual, expected)
+
+
+def test_merge_slide():
+    s = cirq.Simulator()
+    s1, s2, t, p1, p2, a = cirq.LineQubit.range(6)
+    measure = cirq.Moment(cirq.measure(s1, key='s1'), cirq.measure(s2,
+                                                                   key='s2'),
+                          cirq.measure(t, key='t'))
+
+    # If both paths are clear, the first source square should always be empty.
+    c = cirq.Circuit(cirq.X(p1), cirq.X(p2), cirq.X(s1),
+                     qm.merge_slide(s1, t, s2, p1, p2, a), measure)
+    results = s.run(c, repetitions=100)
+    assert all(r == [0] for r in results.measurements['s1'])

--- a/recirq/quantum_chess/test_utils.py
+++ b/recirq/quantum_chess/test_utils.py
@@ -1,0 +1,88 @@
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections import defaultdict
+from scipy.stats import chisquare
+
+import recirq.quantum_chess.bit_utils as u
+
+
+def print_samples(samples):
+    """For debugging only. Prints all the samples as lists of squares."""
+    sample_dict = {}
+    for sample in samples:
+        if sample not in sample_dict:
+            sample_dict[sample] = 0
+        sample_dict[sample] += 1
+    for key in sample_dict:
+        print(f'{u.bitboard_to_squares(key)}: {sample_dict[key]}')
+
+
+def assert_samples_in(b, possibilities):
+    samples = b.sample(500)
+    assert len(samples) == 500
+    all_in = all(sample in possibilities for sample in samples)
+    print(possibilities)
+    print(set(samples))
+    assert all_in, print_samples(samples)
+    # make sure each is represented at least once
+    for p in possibilities:
+        any_in = any(sample == p for sample in samples)
+        assert any_in, print_samples(samples)
+
+
+def assert_sample_distribution(b, probability_map, p_significant=1e-6):
+    """Performs a chi-squared test that samples follow an expected distribution.
+
+    probability_map is a map from bitboards to expected probability. An
+    assertion is raised if one of the samples is not in the map, or if the
+    probability that the samples are at least as different from the expected
+    ones as the observed sampless is less than p_significant.
+    """
+    assert abs(sum(probability_map.values()) - 1) < 1e-9
+    samples = b.sample(500)
+    assert len(samples) == 500
+    counts = defaultdict(int)
+    for sample in samples:
+        assert sample in probability_map
+        counts[sample] += 1
+    observed = []
+    expected = []
+    for position, probability in probability_map.items():
+        observed.append(counts[position])
+        expected.append(500 * probability)
+    p = chisquare(observed, expected).pvalue
+    print(observed, expected, 'p =', p)
+    assert p > p_significant, (
+        f'Observed {observed} far from expected {expected} (p = {p})')
+
+
+def assert_this_or_that(samples, this, that):
+    """Asserts all the samples are either equal to this or that,
+    and that one of each exists in the samples.
+    """
+    assert any(sample == this for sample in samples)
+    assert any(sample == that for sample in samples)
+    assert all(sample == this or sample == that
+               for sample in samples), print_samples(samples)
+
+
+def assert_prob_about(probs, that, expected, atol=0.04):
+    """Checks that the probability is within atol of the expected value."""
+    assert probs[that] > expected - atol
+    assert probs[that] < expected + atol
+
+
+def assert_fifty_fifty(probs, that):
+    """Checks that the probability is close to 50%."""
+    assert_prob_about(probs, that, 0.5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ scikit-learn
 networkx
 pytket
 pytket-cirq
+
+# quantum chess, only needed for tests
+scipy


### PR DESCRIPTION
- Includes code for translating quantum chess moves into circuits,
decomposing into hardware gates, and mapping qubits.
- Adds scipy (at least temporarily) into requirements.  It is only
used for a few tests though, so we could change it.

Does not yet include documentation or experiment scripts.