### PR TITLE
Add seeded processor to engine_utils

### DIFF
--- a/recirq/engine_utils.py
+++ b/recirq/engine_utils.py
@@ -287,6 +287,17 @@ QUANTUM_PROCESSORS = {
                 qubit_noise_gate=cirq.DepolarizingChannel(0.005)
             ))
     ),
+    'Syc23-simulator-tester': QuantumProcessor(
+        # This simulator has a constant seed for consistent testing
+        name='Syc23-simulator-tester',
+        device_obj=cg_devices.Sycamore23,
+        processor_id=None,
+        is_simulator=True,
+        _get_sampler_func=lambda x, gs: cirq.DensityMatrixSimulator(
+            noise=cirq.ConstantQubitNoiseModel(
+                qubit_noise_gate=cirq.DepolarizingChannel(0.005)
+            ), seed=1234)
+    ),
     'Syc23-zeros': QuantumProcessor(
         name='Syc23-zeros',
         device_obj=cg_devices.Sycamore23,

--- a/recirq/quantum_chess/quantum_board_test.py
+++ b/recirq/quantum_chess/quantum_board_test.py
@@ -40,8 +40,8 @@ ALL_CIRQ_BOARDS = BIG_CIRQ_BOARDS + (
                  device=utils.get_device_obj_by_name('Syc23-noiseless'),
                  error_mitigation=enums.ErrorMitigation.Error),
     qb.CirqBoard(0,
-                 sampler=utils.get_sampler_by_name('Syc23-simulator'),
-                 device=utils.get_device_obj_by_name('Syc23-simulator'),
+                 sampler=utils.get_sampler_by_name('Syc23-simulator-tester'),
+                 device=utils.get_device_obj_by_name('Syc23-simulator-tester'),
                  error_mitigation=enums.ErrorMitigation.Correct,
                  noise_mitigation=0.10),
 )


### PR DESCRIPTION
- Adds a QuantumProcessor with a constant seed.
- This allows tests to be consistent and removes flakiness due
to randomness.

Fixes #66 