### PR TITLE
Update Fermi-Hubbard docs index

### DIFF
--- a/docs/fermi_hubbard/index.md
+++ b/docs/fermi_hubbard/index.md
@@ -15,6 +15,4 @@ in [arXiv:2010.07965](https://arxiv.org/abs/2010.07965) **[quant-ph]**:
   analysis of results from the data set which was released together with the publication.
   The data set consists of four zip files and can be accessed at 
   [https://doi.org/10.5061/dryad.crjdfn32v](https://doi.org/10.5061/dryad.crjdfn32v).
-  The files need to be downloaded and extracted into the
-  `docs/fermi_hubbard/fermi_hubbard_data/` directory.
   


### PR DESCRIPTION
Small follow up to PR #107 - since the publication_results notebook automatically downloads data now, I removed the sentence from `index.md` saying it must be downloaded. 