### PR TITLE
Bump pytket-cirq dependency to resolve conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ scikit-learn
 # qaoa
 networkx
 pytket==0.6.1
-pytket-cirq==0.5
+pytket-cirq==0.5.1
 
 # quantum chess, only needed for tests
 scipy


### PR DESCRIPTION
There is a dependency conflict when installing ReCirq which causes the latest version of pip (20.3.3) to fail (see below). This PR bumps the `pytket-cirq` dependency to v0.5.1 which uses Cirq v0.9 and resolves the conflict

```
pip install git+https://github.com/quantumlib/recirq

...

ERROR: Cannot install recirq and recirq==0.1.dev0 because these package versions have conflicting dependencies.

The conflict is caused by:
    recirq 0.1.dev0 depends on cirq==0.9.1
    pytket-cirq 0.5.0 depends on cirq~=0.8.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```