### PR TITLE
Use tket 2D qubit indices with new register name

### DIFF
--- a/docs/qaoa/routing_with_tket.ipynb
+++ b/docs/qaoa/routing_with_tket.ipynb
@@ -225,28 +225,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "UZMHX0TfLzh_"
-      },
-      "source": [
-        "### Mapping to device *indices*\n",
-        "We'll keep a set of secret indices that number device qubits contiguously from zero instead of `(row, col)`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qWak5p0QLziB"
-      },
-      "outputs": [],
-      "source": [
-        "index_to_qubit = sorted(device.qubit_set())\n",
-        "qubit_to_index = {q: i for i, q in enumerate(index_to_qubit)}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "G79yrP3_LziE"
       },
       "source": [
@@ -268,8 +246,7 @@
         "def _qubit_index_edges():\n",
         "    dev_graph = ccr.xmon_device_to_graph(device)\n",
         "    for n1, n2 in dev_graph.edges:\n",
-        "        #yield Node('q', n1.row, n1.col), Node('q', n2.row, n2.col)\n",
-        "        yield (qubit_to_index[n1], qubit_to_index[n2])\n",
+        "        yield Node('grid', n1.row, n1.col), Node('grid', n2.row, n2.col)\n",
         "\n",
         "def _device_to_tket_device():\n",
         "    arc = pytket.routing.Architecture(\n",
@@ -287,7 +264,7 @@
         "id": "saC90prWLziI"
       },
       "source": [
-        "### tket understands LineQubit and uses our strange indexing convention"
+        "### tket understands LineQubit and GridQubit and uses our strange indexing convention"
       ]
     },
     {
@@ -299,17 +276,6 @@
       "outputs": [],
       "source": [
         "tk_circuit.qubits"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "9f_kDTkXLziM"
-      },
-      "source": [
-        "### However, our device uses our secret indices\n",
-        "\n",
-        "There seems to be a bug if you use their built-in support for two-index qubits (nodes): `Existing register q cannot support id: q[6, 1]`"
       ]
     },
     {
@@ -369,7 +335,7 @@
       },
       "source": [
         "### The initial mapping\n",
-        "This maps from logical LineQubits to secret device indices"
+        "This maps from logical LineQubits to \"physical\" GridQubits"
       ]
     },
     {
@@ -401,12 +367,11 @@
       },
       "outputs": [],
       "source": [
-        "def tk_to_i(tk):\n",
-        "    i = tk.index\n",
-        "    assert len(i) == 1, i\n",
-        "    return i[0]\n",
+        "def tk_to_cirq_qubit(tk):\n",
+        "    ind = tk.index\n",
+        "    return cirq.LineQubit(ind[0]) if len(ind) == 1 else cirq.GridQid(*ind, dimension=len(ind))\n",
         "\n",
-        "initial_map = {cirq.LineQubit(tk_to_i(n1)): index_to_qubit[tk_to_i(n2)] for n1, n2 in unit.initial_map.items()}\n",
+        "initial_map = {tk_to_cirq_qubit(n1): tk_to_cirq_qubit(n2) for n1, n2 in unit.initial_map.items()}\n",
         "initial_map"
       ]
     },
@@ -417,7 +382,7 @@
       },
       "source": [
         "### The final mapping\n",
-        "This maps from logical LineQubits to final secret device indices."
+        "This maps from logical LineQubits to final GridQubits"
       ]
     },
     {
@@ -439,7 +404,7 @@
       },
       "outputs": [],
       "source": [
-        "final_map = {cirq.LineQubit(tk_to_i(n1)): index_to_qubit[tk_to_i(n2)]\n",
+        "final_map = {tk_to_cirq_qubit(n1): tk_to_cirq_qubit(n2)\n",
         "             for n1, n2 in unit.final_map.items()}\n",
         "final_map"
       ]
@@ -451,7 +416,7 @@
       },
       "source": [
         "### The compilation unit applies the mapping\n",
-        "So our circuit qubits use secret device indices"
+        "So our circuit qubits are now GridQubits"
       ]
     },
     {
@@ -471,7 +436,7 @@
         "id": "JTAFgW8uLzip"
       },
       "source": [
-        "### Map the circuit to grid qubits"
+        "### Convert the circuit back to Cirq"
       ]
     },
     {
@@ -483,7 +448,6 @@
       "outputs": [],
       "source": [
         "routed_circuit = pytket.cirq.tk_to_cirq(unit.circuit)\n",
-        "routed_circuit = routed_circuit.transform_qubits(lambda q: index_to_qubit[q.x])\n",
         "SVGCircuit(routed_circuit)"
       ]
     },
@@ -565,7 +529,8 @@
     },
     "kernelspec": {
       "display_name": "Python 3",
-      "name": "python3"
+      "name": "python3",
+      "language": "python"
     }
   },
   "nbformat": 4,

--- a/docs/qaoa/routing_with_tket.ipynb
+++ b/docs/qaoa/routing_with_tket.ipynb
@@ -259,15 +259,6 @@
       ]
     },
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "saC90prWLziI"
-      },
-      "source": [
-        "### tket understands LineQubit and GridQubit and uses our strange indexing convention"
-      ]
-    },
-    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -369,7 +360,7 @@
       "source": [
         "def tk_to_cirq_qubit(tk):\n",
         "    ind = tk.index\n",
-        "    return cirq.LineQubit(ind[0]) if len(ind) == 1 else cirq.GridQid(*ind, dimension=len(ind))\n",
+        "    return cirq.LineQubit(ind[0]) if len(ind) == 1 else cirq.GridQubit(*ind)\n",
         "\n",
         "initial_map = {tk_to_cirq_qubit(n1): tk_to_cirq_qubit(n2) for n1, n2 in unit.initial_map.items()}\n",
         "initial_map"

--- a/recirq/qaoa/placement.py
+++ b/recirq/qaoa/placement.py
@@ -7,6 +7,7 @@ import networkx as nx
 import numpy as np
 import pytket
 import pytket.cirq
+from pytket.circuit import Node, Qubit
 from pytket.passes import SequencePass, RoutingPass, PlacementPass
 from pytket.predicates import CompilationUnit, ConnectivityPredicate
 from pytket.routing import GraphPlacement
@@ -37,33 +38,34 @@ def calibration_data_to_graph(calib_dict: Dict) -> nx.Graph:
     return err_graph
 
 
-def _qubit_index_edges(device, qubit_to_index):
+def _qubit_index_edges(device):
     """Helper function in `_device_to_tket_device`"""
     dev_graph = ccr.xmon_device_to_graph(device)
     for n1, n2 in dev_graph.edges:
-        yield qubit_to_index[n1], qubit_to_index[n2]
+        yield Node('grid', n1.row, n1.col), Node('grid', n2.row, n2.col)
 
 
-def _device_to_tket_device(device, qubit_to_index):
+def _device_to_tket_device(device):
     """Custom function to turn a device into a pytket device.
-
-    Note: there's a problem if you try to use tket's 2D grid-qubit-like
-    Node objects, so we use the `qubit_to_index` mapping to use contiguous
-    integer Node ids.
 
     This supports any device that supports `ccr.xmon_device_to_graph`.
     """
     arc = pytket.routing.Architecture(
-        list(_qubit_index_edges(device, qubit_to_index))
+        list(_qubit_index_edges(device))
     )
     return pytket.device.Device({}, {}, arc)
 
 
-def _tk_to_i(tk):
-    """Extract an integer from pytket nodes."""
-    i = tk.index
-    assert len(i) == 1, i
-    return i[0]
+def tk_to_cirq_qubit(tk: Qubit):
+    """Convert a tket Qubit to either a LineQubit or GridQubit.
+
+    """
+    ind = tk.index
+    return (
+        cirq.LineQubit(ind[0])
+        if len(ind) == 1
+        else cirq.GridQid(*ind, dimension=len(ind))
+    )
 
 
 def place_on_device(circuit: cirq.Circuit,
@@ -85,10 +87,8 @@ def place_on_device(circuit: cirq.Circuit,
         initial_map: Initial placement of qubits
         final_map: The final placement of qubits after action of the circuit
     """
-    index_to_qubit = sorted(device.qubit_set())
-    qubit_to_index = {q: i for i, q in enumerate(index_to_qubit)}
     tk_circuit = pytket.cirq.cirq_to_tk(circuit)
-    tk_device = _device_to_tket_device(device, qubit_to_index)
+    tk_device = _device_to_tket_device(device)
 
     unit = CompilationUnit(tk_circuit, [ConnectivityPredicate(tk_device)])
     passes = SequencePass([
@@ -99,12 +99,11 @@ def place_on_device(circuit: cirq.Circuit,
     if not valid:
         raise RuntimeError("Routing failed")
 
-    initial_map = {cirq.LineQubit(_tk_to_i(n1)): index_to_qubit[_tk_to_i(n2)] for n1, n2 in
-                   unit.initial_map.items()}
-    final_map = {cirq.LineQubit(_tk_to_i(n1)): index_to_qubit[_tk_to_i(n2)]
-                 for n1, n2 in unit.final_map.items()}
+    initial_map = {tk_to_cirq_qubit(n1): tk_to_cirq_qubit(n2)
+                     for n1, n2 in unit.initial_map.items()}
+    final_map = {tk_to_cirq_qubit(n1): tk_to_cirq_qubit(n2)
+             for n1, n2 in unit.final_map.items()}
     routed_circuit = pytket.cirq.tk_to_cirq(unit.circuit)
-    routed_circuit = routed_circuit.transform_qubits(lambda q: index_to_qubit[q.x])
 
     return routed_circuit, initial_map, final_map
 

--- a/recirq/qaoa/placement.py
+++ b/recirq/qaoa/placement.py
@@ -64,7 +64,7 @@ def tk_to_cirq_qubit(tk: Qubit):
     return (
         cirq.LineQubit(ind[0])
         if len(ind) == 1
-        else cirq.GridQid(*ind, dimension=len(ind))
+        else cirq.GridQubit(*ind)
     )
 
 


### PR DESCRIPTION
Previously it seems 2D registers (as the equivalent of `GridQubit`) were used with "q" as the register name, which lead to failure as "q" is a reserved name in tket for the default 1D register (this should be made more clear in the tket docs/error message). I have changed the name to "grid", and removed the workaround used to map 1D indices to 2D qubits. 