### PR TITLE
[docs] Fix hfvqe molecular data notebook

### DIFF
--- a/docs/hfvqe/molecular_data.ipynb
+++ b/docs/hfvqe/molecular_data.ipynb
@@ -93,7 +93,7 @@
     "try:\n",
     "    import openfermionpyscf\n",
     "except ImportError:\n",
-    "    !pip install --quiet openfermionpyscf"
+    "    !pip install --quiet openfermionpyscf~=0.4.0"
    ]
   },
   {


### PR DESCRIPTION
This notebook installs openfermionpyscf v0.5.0 which is incompatible with recirq (requires openfermion 0.11.0). This small patch pins openfermionpyscf to v0.4.0 to fix the docs build.