### PR TITLE
Better error message for nbfmt

### DIFF
--- a/dev_tools/nbfmt
+++ b/dev_tools/nbfmt
@@ -25,4 +25,10 @@ if [[ ! -f dev_tools/nbformat ]]; then
 fi
 
 # Run the formatter.
-dev_tools/nbformat "$@"
+result=$(dev_tools/nbformat "$@")
+status=$?
+
+# Make sure error message references right file.
+result=${result//"check/nbformat"/"dev_tools/nbfmt"}
+printf '%s\n' "${result[@]}"
+exit $status

--- a/docs/fermi_hubbard/experiment_example.ipynb
+++ b/docs/fermi_hubbard/experiment_example.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "cellView": "form",
     "id": "906e07f6e562"
@@ -999,9 +999,22 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/docs/fermi_hubbard/experiment_example.ipynb
+++ b/docs/fermi_hubbard/experiment_example.ipynb
@@ -999,22 +999,9 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
-   "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/docs/fermi_hubbard/experiment_example.ipynb
+++ b/docs/fermi_hubbard/experiment_example.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "cellView": "form",
     "id": "906e07f6e562"


### PR DESCRIPTION
Follow up from #124. The `nbfmt` error message is the "Cirq error message" which says to run `check/nbformat` which doesn't exist in ReCirq. This PR updates the error message to reference the correct file, namely `dev_tools/nbfmt`. For example:

```bash
The following notebooks require formatting.
- docs/fermi_hubbard/experiment_example.ipynb
Notebooks are not formatted. Please run 'dev_tools/nbfmt --apply'
```