### PR TITLE
Fix batch_move to use correct gateset

### DIFF
--- a/recirq/quantum_chess/experiments/batch_moves.py
+++ b/recirq/quantum_chess/experiments/batch_moves.py
@@ -32,7 +32,7 @@ import recirq.quantum_chess.quantum_board as qb
 def create_board(processor_name: str, *, noise_mitigation: float):
     return qb.CirqBoard(init_basis_state=0,
                         sampler=utils.get_sampler_by_name(
-                            processor_name, gateset=cg.SQRT_ISWAP_GATESET),
+                            processor_name, gateset='sqrt-iswap'),
                         device=utils.get_device_obj_by_name(processor_name),
                         error_mitigation=enums.ErrorMitigation.Correct,
                         noise_mitigation=noise_mitigation)


### PR DESCRIPTION
- QuantumProcessor uses a string to identify gateset instead
of a cirq object, so change the function to use this string.