### PR TITLE
Fix the queen's position in the 'double occupancy' section.

### DIFF
--- a/docs/quantum_chess/concepts.ipynb
+++ b/docs/quantum_chess/concepts.ipynb
@@ -565,7 +565,7 @@
     "id": "gmzaVbLeumP8"
    },
    "source": [
-    "In this configuration, you should see two different results.  If we measured the king to be at 'b2', then the position is resolved to a single basis state, equivalent to a classical position (the king is at 'b2' and the queen is at 'c3').\n",
+    "In this configuration, you should see two different results.  If we measured the king to be at 'b2', then the position is resolved to a single basis state, equivalent to a classical position (the king is at 'b2' and the queen is at 'a3').\n",
     "\n",
     "If the 'b2' square is measured to be empty, then the board is still in a state of superposition.  "
    ]


### PR DESCRIPTION
If we measured the king to be at 'b2', the queen would not be allowed to move and thus would stay in the initial position - 'a3'.