### PR TITLE
Fix PyTket

### DIFF
--- a/docs/qaoa/routing_with_tket.ipynb
+++ b/docs/qaoa/routing_with_tket.ipynb
@@ -93,7 +93,7 @@
     "try:\n",
     "    import recirq\n",
     "except ImportError:\n",
-    "    !pip install -q git+https://github.com/quantumlib/ReCirq"
+    "    !pip install -q git+https://github.com/quantumlib/ReCirq sympy~=1.6"
    ]
   },
   {

--- a/docs/qaoa/routing_with_tket.ipynb
+++ b/docs/qaoa/routing_with_tket.ipynb
@@ -93,7 +93,7 @@
     "try:\n",
     "    import recirq\n",
     "except ImportError:\n",
-    "    !pip install git+https://github.com/quantumlib/ReCirq"
+    "    !pip install -q git+https://github.com/quantumlib/ReCirq"
    ]
   },
   {
@@ -254,7 +254,7 @@
     "    )\n",
     "    return pytket.device.Device({}, {}, arc)\n",
     "\n",
-    "tk_circuit = pytket.cirq.cirq_to_tk(circuit)\n",
+    "tk_circuit = pytket.extensions.cirq.cirq_to_tk(circuit)\n",
     "tk_device = _device_to_tket_device()"
    ]
   },
@@ -438,7 +438,7 @@
    },
    "outputs": [],
    "source": [
-    "routed_circuit = pytket.cirq.tk_to_cirq(unit.circuit)\n",
+    "routed_circuit = pytket.extensions.cirq.tk_to_cirq(unit.circuit)\n",
     "SVGCircuit(routed_circuit)"
    ]
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cirq==0.9.1
+cirq~=0.9.1
 seaborn
 sphinx
 ipython
@@ -8,8 +8,8 @@ scikit-learn
 
 # qaoa
 networkx
-pytket~=0.6.1
-pytket-cirq~=0.5.0
+pytket~=0.7.1
+pytket-cirq~=0.7.0
 
 # quantum chess, only needed for tests
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ scikit-learn
 
 # qaoa
 networkx
-pytket
-pytket-cirq
+pytket~=0.6.1
+pytket-cirq~=0.5.0
 
 # quantum chess, only needed for tests
 scipy


### PR DESCRIPTION
There's something fishy going on with the pytket notebook. When running in the doc build system it says

```python
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-1-2f5bab2028d6> in <module>
     13     return pytket.device.Device({}, {}, arc)
     14 
---> 15 tk_circuit = pytket.cirq.cirq_to_tk(circuit)
     16 tk_device = _device_to_tket_device()

AttributeError: module 'pytket' has no attribute 'cirq'
AttributeError: module 'pytket' has no attribute 'cirq'
```

and when I try to execute it in colab it complains about a bad sympy version

```
ERROR: pytket 0.7.1.1 has requirement sympy~=1.6, but you'll have sympy 1.1.1 which is incompatible.
```

and when I run the import pytket part, the kernel **dies** with some information in the logs:

```
AttributeError: module 'sympy.core.core' has no attribute 'numbers'
```