### PR TITLE
Make AsciiBoard#reset() function actually reset the state of the board.

### DIFF
--- a/recirq/quantum_chess/ascii_board.py
+++ b/recirq/quantum_chess/ascii_board.py
@@ -19,15 +19,23 @@ class AsciiBoard:
                  size: Optional[int] = 8,
                  reps: Optional[int] = 1000,
                  board=None):
-        self._pieces = {}
-        self._sampled = {}
+
+        self.size = size
         self.reps = reps
         self.board = board or qb.CirqBoard(0)
-        for x in range(size):
-            for y in range(size):
+
+        self._reset_state()
+
+    def _reset_state(self):
+        """Resets all the values that represent the state to default values. """
+        self._pieces = {}
+        self._sampled = {}
+
+        for x in range(self.size):
+            for y in range(self.size):
                 s = to_square(x, y)
                 self._pieces[s] = 0
-        self.size = size
+
         self.ep_flag = None
         self.white_moves = True
         self.castling_flags = {
@@ -65,6 +73,7 @@ class AsciiBoard:
 
     def reset(self):
         """Resets to initial classical chess starting position."""
+        self._reset_state()
         if self.size != 8:
             raise ValueError('board size must be 8 for standard chess position')
         self.load_fen('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR')

--- a/recirq/quantum_chess/ascii_board_test.py
+++ b/recirq/quantum_chess/ascii_board_test.py
@@ -1,6 +1,7 @@
 import recirq.quantum_chess.ascii_board as ab
 import recirq.quantum_chess.constants as c
 import recirq.quantum_chess.move as m
+from recirq.quantum_chess.enums import MoveType, MoveVariant
 
 
 def test_squares():
@@ -33,6 +34,18 @@ def test_fen():
         for y in range(8):
             square = m.to_square(x, y)
             assert b._pieces[square] == expected_pieces.get(square, c.EMPTY)
+
+
+def test_fen_existing_state():
+    b = ab.AsciiBoard()
+    b.reset()
+    b.apply(
+        m.Move(source='b1', target='a3', target2='c3', move_type=MoveType.SPLIT_JUMP, move_variant=MoveVariant.BASIC))
+    b.reset()
+
+    expected_board = ab.AsciiBoard()
+    expected_board.reset()
+    assert str(b) == str(expected_board)
 
 
 def test_ep_flag():


### PR DESCRIPTION
Currently, after resetting to initial classical chess starting position and moving a piece (i.e. b2b3), the board will be
as follows: 'rnbqkbnr/pppppppp/8/8/8/P7/PPPPPPPP/RNBQKBNR' (instead of 8 in the 6th row).