### PR TITLE
Allow measurement outcomes to be provided to the quantum board when performing moves

### DIFF
--- a/recirq/quantum_chess/move.py
+++ b/recirq/quantum_chess/move.py
@@ -46,7 +46,6 @@ class Move:
     have a move type and variant that determines what kind of move this is
     (capture, exclusion, etc).
     """
-
     def __init__(self,
                  source: str,
                  target: str,
@@ -54,19 +53,23 @@ class Move:
                  source2: str = None,
                  target2: str = None,
                  move_type: enums.MoveType = None,
-                 move_variant: enums.MoveVariant = None):
+                 move_variant: enums.MoveVariant = None,
+                 measurement: bool = None):
         self.source = source
         self.source2 = source2
         self.target = target
         self.target2 = target2
         self.move_type = move_type
         self.move_variant = move_variant
+        self.measurement = measurement
 
     def __eq__(self, other):
         if isinstance(other, Move):
-            return (self.source == other.source and
-                    self.target == other.target and
-                    self.target2 == other.target2)
+            return (self.source == other.source and self.target == other.target
+                    and self.target2 == other.target2
+                    and self.move_type == other.move_type
+                    and self.move_variant == other.move_variant
+                    and self.measurement == other.measurement)
         return False
 
     @classmethod
@@ -74,7 +77,7 @@ class Move:
         """Creates a move from a string shorthand for tests.
 
 
-        Format=source,target,target2,source2:type:variant
+        Format=source,target,target2,source2[.measurement]:type:variant
         with commas omitted.
 
         if target2 is specified, then source2 should
@@ -83,6 +86,7 @@ class Move:
         Examples:
            'a1a2:JUMP:BASIC'
            'b1a3c3:SPLIT_JUMP:BASIC'
+           'b1a3c3.m0:SPLIT_JUMP:BASIC'
            'a3b1--c3:MERGE_JUMP:BASIC'
         """
         fields = str_to_parse.split(':')
@@ -90,24 +94,36 @@ class Move:
             raise ValueError(f'Invalid move string {str_to_parse}')
         source = fields[0][0:2]
         target = fields[0][2:4]
+
+        move_and_measurement = fields[0].split('.', maxsplit=1)
+        measurement = None
+        if len(move_and_measurement) == 2:
+            _, m_str = move_and_measurement
+            if m_str != 'm0' and m_str != 'm1':
+                raise ValueError(f'Invalid measurement string {m_str}')
+            measurement = (m_str == 'm1')
+
         move_type = enums.MoveType[fields[1]]
         move_variant = enums.MoveVariant[fields[2]]
         if len(fields[0]) <= 4:
             return cls(source,
                        target,
                        move_type=move_type,
-                       move_variant=move_variant)
+                       move_variant=move_variant,
+                       measurement=measurement)
         if len(fields[0]) <= 6:
             return cls(source,
                        target,
                        target2=fields[0][4:6],
                        move_type=move_type,
-                       move_variant=move_variant)
+                       move_variant=move_variant,
+                       measurement=measurement)
         return cls(source,
                    target,
                    source2=fields[0][6:8],
                    move_type=move_type,
-                   move_variant=move_variant)
+                   move_variant=move_variant,
+                   measurement=measurement)
 
     def is_split_move(self) -> bool:
         return self.target2 is not None
@@ -115,9 +131,17 @@ class Move:
     def is_merge_move(self) -> bool:
         return self.source2 is not None
 
+    def has_measurement(self) -> bool:
+        return self.measurement is not None
+
     def __str__(self):
+        movestr = self.source + self.target
         if self.is_split_move():
-            return self.source + '^' + self.target + self.target2
+            movestr = self.source + '^' + self.target + self.target2
         if self.is_merge_move():
-            return self.source + self.source2 + '^' + self.target
-        return self.source + self.target
+            movestr = self.source + self.source2 + '^' + self.target
+
+        if self.has_measurement():
+            return movestr + ('.m1' if self.measurement else '.m0')
+        else:
+            return movestr

--- a/recirq/quantum_chess/move.py
+++ b/recirq/quantum_chess/move.py
@@ -54,7 +54,7 @@ class Move:
                  target2: str = None,
                  move_type: enums.MoveType = None,
                  move_variant: enums.MoveVariant = None,
-                 measurement: bool = None):
+                 measurement: int = None):
         self.source = source
         self.source2 = source2
         self.target = target
@@ -87,6 +87,7 @@ class Move:
            'a1a2:JUMP:BASIC'
            'b1a3c3:SPLIT_JUMP:BASIC'
            'b1a3c3.m0:SPLIT_JUMP:BASIC'
+           'b1a3c3.m1:SPLIT_JUMP:BASIC'
            'a3b1--c3:MERGE_JUMP:BASIC'
         """
         fields = str_to_parse.split(':')
@@ -99,9 +100,9 @@ class Move:
         measurement = None
         if len(move_and_measurement) == 2:
             _, m_str = move_and_measurement
-            if m_str != 'm0' and m_str != 'm1':
+            if m_str[0] != 'm':
                 raise ValueError(f'Invalid measurement string {m_str}')
-            measurement = (m_str == 'm1')
+            measurement = int(m_str[1:])
 
         move_type = enums.MoveType[fields[1]]
         move_variant = enums.MoveVariant[fields[2]]
@@ -142,6 +143,6 @@ class Move:
             movestr = self.source + self.source2 + '^' + self.target
 
         if self.has_measurement():
-            return movestr + ('.m1' if self.measurement else '.m0')
+            return movestr + '.m' + str(self.measurement)
         else:
             return movestr

--- a/recirq/quantum_chess/move_test.py
+++ b/recirq/quantum_chess/move_test.py
@@ -12,9 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import recirq.quantum_chess.move as move
+import recirq.quantum_chess.enums as enums
 
 
 def test_equality():
     assert move.Move('a1', 'b4') == move.Move('a1', 'b4')
     assert move.Move('a1', 'b4') != move.Move('a1', 'b5')
     assert move.Move('a1', 'b4') != "a1b4"
+
+    assert move.Move('a1', 'b4',
+                     measurement=True) == move.Move('a1',
+                                                    'b4',
+                                                    measurement=True)
+    assert move.Move('a1', 'b4', measurement=True) != move.Move(
+        'a1', 'b4', measurement=False)
+    assert move.Move('a1', 'b4', measurement=True) != move.Move('a1', 'b4')
+
+    assert move.Move('a1', 'b4', move_type=enums.MoveType.JUMP) == move.Move(
+        'a1', 'b4', move_type=enums.MoveType.JUMP)
+    assert move.Move('a1', 'b4', move_type=enums.MoveType.JUMP) != move.Move(
+        'a1', 'b4', move_type=enums.MoveType.SLIDE)
+
+
+def test_from_string():
+    assert move.Move.from_string('a1b4:JUMP:BASIC') == move.Move(
+        'a1',
+        'b4',
+        move_type=enums.MoveType.JUMP,
+        move_variant=enums.MoveVariant.BASIC)
+    assert move.Move.from_string('a1b4.m0:JUMP:BASIC') == move.Move(
+        'a1',
+        'b4',
+        move_type=enums.MoveType.JUMP,
+        move_variant=enums.MoveVariant.BASIC,
+        measurement=False)
+    assert move.Move.from_string('a1b4.m1:JUMP:BASIC') == move.Move(
+        'a1',
+        'b4',
+        move_type=enums.MoveType.JUMP,
+        move_variant=enums.MoveVariant.BASIC,
+        measurement=True)
+
+
+def test_to_string():
+    assert str(move.Move('a1', 'b4')) == 'a1b4'
+    assert str(move.Move('a1', 'b4', target2='c4')) == 'a1^b4c4'
+    assert str(move.Move('a1', 'b4', source2='b1')) == 'a1b1^b4'
+    assert str(move.Move('a1', 'b4', measurement=True)) == 'a1b4.m1'
+    assert str(move.Move('a1', 'b4', source2='b1',
+                         measurement=False)) == 'a1b1^b4.m0'

--- a/recirq/quantum_chess/move_test.py
+++ b/recirq/quantum_chess/move_test.py
@@ -21,12 +21,12 @@ def test_equality():
     assert move.Move('a1', 'b4') != "a1b4"
 
     assert move.Move('a1', 'b4',
-                     measurement=True) == move.Move('a1',
+                     measurement=1) == move.Move('a1',
                                                     'b4',
-                                                    measurement=True)
-    assert move.Move('a1', 'b4', measurement=True) != move.Move(
-        'a1', 'b4', measurement=False)
-    assert move.Move('a1', 'b4', measurement=True) != move.Move('a1', 'b4')
+                                                    measurement=1)
+    assert move.Move('a1', 'b4', measurement=1) != move.Move(
+        'a1', 'b4', measurement=0)
+    assert move.Move('a1', 'b4', measurement=1) != move.Move('a1', 'b4')
 
     assert move.Move('a1', 'b4', move_type=enums.MoveType.JUMP) == move.Move(
         'a1', 'b4', move_type=enums.MoveType.JUMP)
@@ -45,19 +45,19 @@ def test_from_string():
         'b4',
         move_type=enums.MoveType.JUMP,
         move_variant=enums.MoveVariant.BASIC,
-        measurement=False)
+        measurement=0)
     assert move.Move.from_string('a1b4.m1:JUMP:BASIC') == move.Move(
         'a1',
         'b4',
         move_type=enums.MoveType.JUMP,
         move_variant=enums.MoveVariant.BASIC,
-        measurement=True)
+        measurement=1)
 
 
 def test_to_string():
     assert str(move.Move('a1', 'b4')) == 'a1b4'
     assert str(move.Move('a1', 'b4', target2='c4')) == 'a1^b4c4'
     assert str(move.Move('a1', 'b4', source2='b1')) == 'a1b1^b4'
-    assert str(move.Move('a1', 'b4', measurement=True)) == 'a1b4.m1'
+    assert str(move.Move('a1', 'b4', measurement=1)) == 'a1b4.m1'
     assert str(move.Move('a1', 'b4', source2='b1',
-                         measurement=False)) == 'a1b1^b4.m0'
+                         measurement=0)) == 'a1b1^b4.m0'

--- a/recirq/quantum_chess/quantum_board.py
+++ b/recirq/quantum_chess/quantum_board.py
@@ -481,7 +481,8 @@ class CirqBoard:
     def post_select_on(self, qubit: cirq.Qid, measurement_outcome: Optional[bool] = None) -> int:
         """Adds a post-selection requirement to the circuit.
 
-        If no measurement_outcome is provided, performs a single sample of the qubit to get a value for the post-selection condition.
+        If no measurement_outcome is provided, performs a single sample of the
+        qubit to get a value for the post-selection condition.
         Adjusts the post-selection requirements dictionary to this value.
         If this qubit is a square qubit, it adjusts the classical register
         to match the sample result.

--- a/recirq/quantum_chess/quantum_board.py
+++ b/recirq/quantum_chess/quantum_board.py
@@ -478,7 +478,8 @@ class CirqBoard:
             qm.queenside_castle(squbit, rook_squbit, tqubit, rook_tqubit,
                                 b_qubit))
 
-    def post_select_on(self, qubit: cirq.Qid, measurement_outcome: Optional[bool] = None) -> int:
+    def post_select_on(self, qubit: cirq.Qid,
+                       measurement_outcome: Optional[int] = None) -> bool:
         """Adds a post-selection requirement to the circuit.
 
         If no measurement_outcome is provided, performs a single sample of the
@@ -493,12 +494,9 @@ class CirqBoard:
                 post-selection is conditioned on the qubit having the given
                 outcome. If absent, a single measurement is performed instead.
 
-        Returns: the sample result as 1 or 0.
+        Returns: the measurement outcome or sample result as 1 or 0.
         """
-        result = None
-        if measurement_outcome is not None:
-            result = 1 if measurement_outcome else 0
-
+        result = measurement_outcome
         if 'anc' in qubit.name:
             if result is None:
                 ancilla_result = []

--- a/recirq/quantum_chess/quantum_board_test.py
+++ b/recirq/quantum_chess/quantum_board_test.py
@@ -981,11 +981,12 @@ def test_split_capture_with_successful_measurement_outcome(board):
         b.do_move(
             move.Move('a3', 'c3', move_type=enums.MoveType.JUMP,
                       move_variant=enums.MoveVariant.CAPTURE,
-                      measurement=True))
+                      measurement=1))
         samples = b.sample(100)
         # The only possible outcome is successful capture.
-        expected = u.squares_to_bitboard(['c3'])
-        assert all(sample == expected for sample in samples)
+        expected = {'c3'}
+        for sample in samples:
+            assert set(u.bitboard_to_squares(sample)) == expected
 
 @pytest.mark.parametrize('board', ALL_CIRQ_BOARDS)
 def test_split_capture_with_failed_measurement_outcome(board):
@@ -1005,9 +1006,10 @@ def test_split_capture_with_failed_measurement_outcome(board):
             move.Move('a3', 'c3',
                       move_type=enums.MoveType.JUMP,
                       move_variant=enums.MoveVariant.CAPTURE,
-                      measurement=False))
+                      measurement=0))
         samples = b.sample(100)
         # The only possible outcome is unsuccessful capture -- a1 jumped to a2,
         # not a3, and the to-be-captured piece on c3 still remains.
-        expected = u.squares_to_bitboard(['a2', 'c3'])
-        assert all(sample == expected for sample in samples)
+        expected = {'a2', 'c3'}
+        for sample in samples:
+            assert set(u.bitboard_to_squares(sample)) == expected

--- a/recirq/quantum_chess/quantum_board_test.py
+++ b/recirq/quantum_chess/quantum_board_test.py
@@ -1007,9 +1007,11 @@ def test_split_capture_with_failed_measurement_outcome(board):
                       move_type=enums.MoveType.JUMP,
                       move_variant=enums.MoveVariant.CAPTURE,
                       measurement=0))
-        samples = b.sample(100)
         # The only possible outcome is unsuccessful capture -- a1 jumped to a2,
         # not a3, and the to-be-captured piece on c3 still remains.
-        expected = {'a2', 'c3'}
-        for sample in samples:
-            assert set(u.bitboard_to_squares(sample)) == expected
+        # However, in the presence of readout error, we may not measure the
+        # piece on either a2 or a3 so post-filtered samples may not contain a2
+        # in rare cases.
+        probs = b.get_probability_distribution(100)
+        assert_prob_about(probs, u.square_to_bit('a2'), 1)
+        assert_prob_about(probs, u.square_to_bit('a3'), 0)


### PR DESCRIPTION
Part of fixing issue #152
* adds an optional measurement outcome field to Move objects
* use that measurement outcome instead of sampling if present when performing moves 