### PR TITLE
Make FH `fetch_publication_data` more stable

### DIFF
--- a/recirq/fermi_hubbard/publication.py
+++ b/recirq/fermi_hubbard/publication.py
@@ -17,7 +17,7 @@ from copy import deepcopy
 from io import BytesIO
 import os
 import re
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, Optional, Tuple
 from urllib.request import urlopen
 from zipfile import ZipFile
 

--- a/recirq/fermi_hubbard/publication.py
+++ b/recirq/fermi_hubbard/publication.py
@@ -246,8 +246,7 @@ def fetch_publication_data(
 
     # Determine file IDs. Note these are not permanent on Dryad.
     file_ids = {}
-    lines = urlopen("https://doi.org/10.5061/dryad.crjdfn32v").readlines()
-    for line in lines:
+    for line in urlopen("https://doi.org/10.5061/dryad.crjdfn32v").readlines():
         for fname in fnames:
             if fname + ".zip" in line.decode():
                 file_id, = re.findall(r"file_stream/[\d]*\d+", line.decode())

--- a/recirq/fermi_hubbard/publication_test.py
+++ b/recirq/fermi_hubbard/publication_test.py
@@ -18,10 +18,10 @@ from recirq.fermi_hubbard.publication import fetch_publication_data
 
 def test_fetch_publication_data():
     base_dir = "fermi_hubbard_data"
-    fetch_publication_data(base_dir=base_dir, exclude=["trapping_3u3d"])
+    fetch_publication_data(base_dir=base_dir, exclude=("trapping_3u3d",))
 
     for path in ("gaussians_1u1d_nofloquet", "gaussians_1u1d", "trapping_2u2d"):
-        assert os.path.exists(base_dir + os.path.sep + path)
+        assert os.path.exists(os.path.join(base_dir, path))
 
     fetch_publication_data(base_dir=base_dir)
-    assert os.path.exists(base_dir + os.path.sep + "trapping_3u3d")
+    assert os.path.exists(os.path.join(base_dir, "trapping_3u3d"))


### PR DESCRIPTION
Fixes #165.

As documented there, individual file IDs are not permanent on Dryad. The strategy here is to determine these from the (permanent) DOI. 

Could be a cleaner way to do this, comments welcome.