### PR TITLE
Add rep rate benchmark to ReCirq

### DIFF
--- a/recirq/benchmarks/README.md
+++ b/recirq/benchmarks/README.md
@@ -1,0 +1,22 @@
+Benchmarks in ReCirq
+
+This package is home to benchmarks used for testing and measuring
+end-to-end performance on hardware, specifically Google's Quantum Computing
+Service.
+
+Benchmarks here are designed to test the performance of the system in various
+aspects and to give an estimate of the processor's performance.  These metrics
+can also be used to replicate the processor's data sheet.
+
+Benchmarks here include:
+
+*   Repetition Rate calculator (rep_rate):  This benchmark will time circuits
+to estimate time taken for circuits of given width, depth, and number of sweeps.
+Due to the complexity of the stack and various bottlenecks at different stages,
+the repetition rate (number of circuits executed per second) can vary widely
+depending on the nature of the circuit being run.  This calculator can help
+figure out how long a circuit execution will take.
+
+Note that this package does not include methods for characterization and
+calibration of individual qubits and gates.  These can be found in the
+cirq repository (cirq.qcvv).

--- a/recirq/benchmarks/rep_rate/rep_rate_calculator.py
+++ b/recirq/benchmarks/rep_rate/rep_rate_calculator.py
@@ -1,0 +1,227 @@
+"""
+  Class to calculate latency and repetition rate.
+
+  This class should replicate the acquisition of date for
+  rep rate and latency for processor data sheets.
+"""
+import random
+import cirq
+import cirq_google as cg
+import time
+import sympy
+
+from typing import List, Optional, Tuple
+
+
+class RepRateCalculator:
+    """Class to perform simple timing experiments using hardware.
+
+    This class calculates the repetition rate for various
+    types of circuits.  This is the approximate type per repetition
+    (or shot) to execute this on the device.  This rate varies widely
+    based on width, depth, and amount of sweeps/batching in the
+    circuit.  This class will help test various rates on the device.
+
+    This class is used to generate statistics on the processor datasheets
+    for latency and repetition rates.
+    """
+
+    def __init__(self,
+                 project_id: str,
+                 processor_id: str,
+                 gate_set: Optional[cg.SerializableGateSet] = None,
+                 device: Optional[cirq.Device] = None,
+                 sampler: Optional[cirq.Sampler] = None):
+        """Initialize the tester object.
+
+        Args:
+            project_id: Cloud project id as a string
+            processor_id: Processor to test on
+            gate_set: gate set to use.  Defaults to square root of iswap
+            device: device object to use. defaults to device provided by engine
+            sampler: sampler object to use.  defaults to engine sampler
+        """
+        if not device or not sampler:
+            engine = cg.Engine(project_id=project_id)
+        gate_set = gate_set or cg.SQRT_ISWAP_GATESET
+        self.device = device or engine.get_processor(processor_id).get_device(
+            gate_sets=[gate_set])
+        self.sampler = sampler or engine.sampler(processor_id=processor_id,
+                                                 gate_set=gate_set)
+        self.gate = cirq.ISWAP**0.5
+        self.qubits = list(self.device.qubits)
+        if gate_set == cg.SYC_GATESET:
+            self.gate = cirq.google.SYC
+
+        # log of print statements for testing
+        self.print_log = ''
+
+    def _flush_print_log(self):
+        self.print_log = ''
+
+    def _print(self, s:str):
+        """Includes printing to testing log and flushing."""
+        self.print_log += s
+        print(s, flush=True)
+
+    def _latency_circuit(self) -> cirq.Circuit:
+        """Circuit for measuring round-trip latency.
+
+        Use the most simple circuit possible, a measurement of a single
+        random qubit.
+        """
+        return cirq.Circuit(cirq.measure(random.choice(self.qubits)))
+
+    def _entangling_layer(self, qubits: List[cirq.Qid]) -> cirq.Moment:
+        """Creates a layer of random two-qubit gates."""
+        m = cirq.Moment()
+        for q in qubits:
+            if q in m.qubits:
+              continue
+            pairings = [
+                q + adj
+                for adj in [(0, 1), (1, 0), (0, -1), (-1, 0)]
+                if q + adj in qubits and q + adj not in m.qubits
+            ]
+            if not pairings:
+                continue
+            q2 = random.choice(pairings)
+            m=m.with_operation(self.gate(q, q2))
+        return m
+
+    def _sq_layer(self, qubits: List[cirq.Qid], parameterized: bool,
+                 symbol_start: int) -> (cirq.Moment, int):
+        """Creates a layer of single-qubit gates.
+
+        If parameteried is true, this will add symbols to the qubits
+        in order to test parameter resolution.
+        """
+        m = cirq.Moment()
+        current_sym = symbol_start
+        for q in qubits:
+            if parameterized:
+                symbol = f's_{current_sym}'
+                current_sym += 1
+                m=m.with_operation(cirq.X(q)**sympy.Symbol(symbol))
+            else:
+                m=m.with_operation(
+                    cirq.PhasedXZGate(x_exponent=random.random(),
+                                      z_exponent=random.random(),
+                                      axis_phase_exponent=random.random())(q))
+        return (m, current_sym)
+
+    def _create_rep_rate_circuit(self, parameterized: bool, width: int,
+                                depth: int, num_sweeps: Optional[int]) -> Tuple[cirq.Circuit, cirq.Sweep]:
+        """Creates a testing circuit based on parameters.
+
+        The circuit will be of alternating single and two qubit layers
+        using a number of qubits specified by width and a number of
+        moments specified by depth.
+
+        This function will also create a sweep if parameterized is true,
+        by parameterized all single qubit layers with random values for
+        angles.
+        """
+        qubits = self.qubits[:width]
+        c = cirq.Circuit()
+        symbol_count = 0
+        for layer in range(depth):
+            if layer % 2:
+                moment, symbol_count = self._sq_layer(qubits, parameterized,
+                                                     symbol_count)
+                c.append(moment)
+            else:
+                c.append(self._entangling_layer(qubits))
+        c.append(cirq.Moment(cirq.measure(*qubits)))
+
+        if not parameterized:
+            return (c, None)
+        sweeps = cirq.Zip(*[
+            cirq.Linspace('s_%d' % i, start=0, stop=1, length=num_sweeps)
+            for i in range(symbol_count)
+        ])
+        return (c, sweeps)
+
+    def get_samples(self, circuit:cirq.Circuit, num_trials:int)->List[float]:
+        """Use a sampler to execute the circuit num_trial times.
+
+        Returns:
+           a list of durations, in seconds for the executions.
+        """
+        latencies = []
+        for trial in range(num_trials):
+            self._print(f'Executing Trial {trial}\n')
+            start = time.time()
+            self.sampler.run(circuit, repetitions=100)
+            end = time.time()
+            duration = end - start
+            latencies.append(duration)
+            self._print(f'Finished Trial {trial} with duration {duration}')
+        return latencies
+
+    def get_latency_samples(self, num_trials: int) -> List[float]:
+        return self.get_samples(self._latency_circuit(), num_trials)
+
+    def print_latency(self, num_trials: int) -> None:
+        latencies = self.get_latency_samples(num_trials)
+        latencies = sorted(latencies)
+        median = latencies[len(latencies) // 2]
+        p05 = latencies[len(latencies) // 20]
+        p95 = latencies[-len(latencies) // 20]
+        p10 = latencies[len(latencies) // 20]
+        p90 = latencies[-len(latencies) // 20]
+        average = sum(latencies) / len(latencies)
+        # Set an internal variable for testing
+        self._print(str(latencies))
+        self._print(f'Median={median}, p05={p05}, p10={p10}, ')
+        self._print(f'p90={p90}. p95={p95}, avg = {average}')
+
+    def print_rep_rate(self,
+                       parameterized: Optional[bool] = True,
+                       width: Optional[int] = None,
+                       depth: Optional[int] = 20,
+                       num_sweeps: Optional[int] = 10,
+                       repetitions: Optional[int] = 1000,
+                       num_trials: Optional[int] = 10,
+                       subtract_latency: Optional[float] = 0.0):
+        if not width:
+            width = len(self.qubits)
+        circuit, sweep = self._create_rep_rate_circuit(parameterized, width,
+                                                      depth, num_sweeps)
+        latencies = []
+        total_reps = repetitions
+        if num_sweeps > 1:
+            total_reps = num_sweeps * repetitions
+        for trial in range(num_trials):
+            self._print(f'Executing Trial {trial}')
+            start = time.time()
+            if sweep:
+                self.sampler.run_sweep(circuit,
+                                       params=sweep,
+                                       repetitions=repetitions)
+            else:
+                self.sampler.run(circuit, repetitions=repetitions)
+            end = time.time()
+            duration = end - start
+            self._print(f'Finished Trial {trial} with duration {duration}')
+            latencies.append(duration)
+        latencies = sorted(latencies)
+        median = latencies[len(latencies) // 2]
+        p05 = latencies[len(latencies) // 20]
+        p95 = latencies[-len(latencies) // 20]
+        p10 = latencies[len(latencies) // 10]
+        p90 = latencies[-len(latencies) // 10]
+        average = sum(latencies) / len(latencies)
+        self._print(latencies)
+        self._print(
+            f'Latency,  Median={median}, p05={p05}, p10={p10}, p90={p90}, p95={p95}, avg = {average}')
+        self._print(f'Total reps: {total_reps}')
+        median = total_reps / (median - subtract_latency)
+        p05 = total_reps / (p05 - subtract_latency)
+        p95 = total_reps / (p95 - subtract_latency)
+        p10 = total_reps / (p10 - subtract_latency)
+        p90 = total_reps / (p90 - subtract_latency)
+        average = total_reps / (average - subtract_latency)
+        self._print(
+            f'Rep Rate,  Median={median}, p05={p05}, p95={p95}, avg = {average}'
+        )

--- a/recirq/benchmarks/rep_rate/rep_rate_calculator.py
+++ b/recirq/benchmarks/rep_rate/rep_rate_calculator.py
@@ -143,10 +143,9 @@ class RepRateCalculator:
             processor_id: Processor to test on.
         """
         gate_set = gate_set or cg.SQRT_ISWAP_GATESET
-        device = device or engine.get_processor(processor_id).get_device(
+        device = engine.get_processor(processor_id).get_device(
             gate_sets=[gate_set])
-        sampler = sampler or engine.sampler(processor_id=processor_id,
-                                            gate_set=gate_set)
+        sampler = engine.sampler(processor_id=processor_id, gate_set=gate_set)
         gate = cirq.ISWAP**0.5
         if gate_set == cg.SYC_GATESET:
             gate = cirq.google.SYC

--- a/recirq/benchmarks/rep_rate/rep_rate_calculator.py
+++ b/recirq/benchmarks/rep_rate/rep_rate_calculator.py
@@ -56,12 +56,14 @@ class RepRateCalculator:
         # log of print statements for testing
         self.print_log = ''
 
-    def _flush_print_log(self):
+    def _flush_print_log(self) -> None:
+        """Remove print log used fro debugging."""
         self.print_log = ''
 
-    def _print(self, s:str):
+    def _print(self, s: str) -> None:
         """Includes printing to testing log and flushing."""
         self.print_log += s
+        self.print_log += '\n'
         print(s, flush=True)
 
     def _latency_circuit(self) -> cirq.Circuit:
@@ -77,7 +79,7 @@ class RepRateCalculator:
         m = cirq.Moment()
         for q in qubits:
             if q in m.qubits:
-              continue
+                continue
             pairings = [
                 q + adj
                 for adj in [(0, 1), (1, 0), (0, -1), (-1, 0)]
@@ -86,11 +88,11 @@ class RepRateCalculator:
             if not pairings:
                 continue
             q2 = random.choice(pairings)
-            m=m.with_operation(self.gate(q, q2))
+            m = m.with_operation(self.gate(q, q2))
         return m
 
     def _sq_layer(self, qubits: List[cirq.Qid], parameterized: bool,
-                 symbol_start: int) -> (cirq.Moment, int):
+                  symbol_start: int) -> (cirq.Moment, int):
         """Creates a layer of single-qubit gates.
 
         If parameteried is true, this will add symbols to the qubits
@@ -102,16 +104,17 @@ class RepRateCalculator:
             if parameterized:
                 symbol = f's_{current_sym}'
                 current_sym += 1
-                m=m.with_operation(cirq.X(q)**sympy.Symbol(symbol))
+                m = m.with_operation(cirq.X(q)**sympy.Symbol(symbol))
             else:
-                m=m.with_operation(
+                m = m.with_operation(
                     cirq.PhasedXZGate(x_exponent=random.random(),
                                       z_exponent=random.random(),
                                       axis_phase_exponent=random.random())(q))
         return (m, current_sym)
 
-    def _create_rep_rate_circuit(self, parameterized: bool, width: int,
-                                depth: int, num_sweeps: Optional[int]) -> Tuple[cirq.Circuit, cirq.Sweep]:
+    def _create_rep_rate_circuit(
+            self, parameterized: bool, width: int, depth: int,
+            num_sweeps: Optional[int]) -> Tuple[cirq.Circuit, cirq.Sweep]:
         """Creates a testing circuit based on parameters.
 
         The circuit will be of alternating single and two qubit layers
@@ -128,7 +131,7 @@ class RepRateCalculator:
         for layer in range(depth):
             if layer % 2:
                 moment, symbol_count = self._sq_layer(qubits, parameterized,
-                                                     symbol_count)
+                                                      symbol_count)
                 c.append(moment)
             else:
                 c.append(self._entangling_layer(qubits))
@@ -142,7 +145,8 @@ class RepRateCalculator:
         ])
         return (c, sweeps)
 
-    def get_samples(self, circuit:cirq.Circuit, num_trials:int)->List[float]:
+    def get_samples(self, circuit: cirq.Circuit,
+                    num_trials: int) -> List[float]:
         """Use a sampler to execute the circuit num_trial times.
 
         Returns:
@@ -150,7 +154,7 @@ class RepRateCalculator:
         """
         latencies = []
         for trial in range(num_trials):
-            self._print(f'Executing Trial {trial}\n')
+            self._print(f'Executing Trial {trial}')
             start = time.time()
             self.sampler.run(circuit, repetitions=100)
             end = time.time()
@@ -163,6 +167,7 @@ class RepRateCalculator:
         return self.get_samples(self._latency_circuit(), num_trials)
 
     def print_latency(self, num_trials: int) -> None:
+        self._flush_print_log()
         latencies = self.get_latency_samples(num_trials)
         latencies = sorted(latencies)
         median = latencies[len(latencies) // 2]
@@ -173,8 +178,8 @@ class RepRateCalculator:
         average = sum(latencies) / len(latencies)
         # Set an internal variable for testing
         self._print(str(latencies))
-        self._print(f'Median={median}, p05={p05}, p10={p10}, ')
-        self._print(f'p90={p90}. p95={p95}, avg = {average}')
+        self._print(f'Latency: Median={median}, p05={p05}, p10={p10}, ' +
+                    f'p90={p90}, p95={p95}, avg={average}')
 
     def print_rep_rate(self,
                        parameterized: Optional[bool] = True,
@@ -183,11 +188,41 @@ class RepRateCalculator:
                        num_sweeps: Optional[int] = 10,
                        repetitions: Optional[int] = 1000,
                        num_trials: Optional[int] = 10,
-                       subtract_latency: Optional[float] = 0.0):
+                       subtract_latency: Optional[float] = 0.0) -> None:
+        """Executes a circuit to determine the repetition rate of the processor.
+
+        Creates a circuit of alternating single and two qubit layers with the
+        specified parameters.  Executes it the specified number of times
+        to get an estimate for the repetition rate (how many repetitions of
+        a circuit execution per second) for the given circuit.
+
+        Displays the latencies for each circuit followed by the median,
+        5,10,90, and 95th percentile values for latency and rep rate.
+        Statistics are also logged to the member value print_log for
+        testing and automatic processing.
+
+        Args:
+            parameterized: Whether to put in symbols for signle-qubit layers.
+            width: number of qubits to use on the device.  qubits are used
+                in the order of the device layout.
+            depth: Number of moments for the circuit.  Moments will alternate
+                between single-qubit and two-qubit gates.
+            num_sweeps:  Number of different parameters to set for each single
+                qubit gate.  Only relevant if parameterized is True.
+            repetitions: Number of repetitions (samples) to run for each circuit.
+            num_trials: The number of iterations to run each sweeped circuit.
+                This will make num_trials independent calls to get a better
+                idea of the average and variance of the rate.
+            subtract_latency: A value, in seconds, to subtract from the end-to-end
+                duration in order to determine repetition rate.  Useful if you
+                would like to remove network latency or other round-trip effects
+                for calculating run-times of circuits with high numbers of repetitions.
+        """
+        self._flush_print_log()
         if not width:
             width = len(self.qubits)
         circuit, sweep = self._create_rep_rate_circuit(parameterized, width,
-                                                      depth, num_sweeps)
+                                                       depth, num_sweeps)
         latencies = []
         total_reps = repetitions
         if num_sweeps > 1:
@@ -212,9 +247,10 @@ class RepRateCalculator:
         p10 = latencies[len(latencies) // 10]
         p90 = latencies[-len(latencies) // 10]
         average = sum(latencies) / len(latencies)
-        self._print(latencies)
+        self._print(str(latencies))
         self._print(
-            f'Latency,  Median={median}, p05={p05}, p10={p10}, p90={p90}, p95={p95}, avg = {average}')
+            f'Latency:  Median={median}, p05={p05}, p10={p10}, p90={p90}, p95={p95}, avg={average}'
+        )
         self._print(f'Total reps: {total_reps}')
         median = total_reps / (median - subtract_latency)
         p05 = total_reps / (p05 - subtract_latency)
@@ -223,5 +259,5 @@ class RepRateCalculator:
         p90 = total_reps / (p90 - subtract_latency)
         average = total_reps / (average - subtract_latency)
         self._print(
-            f'Rep Rate,  Median={median}, p05={p05}, p95={p95}, avg = {average}'
+            f'Rep Rate:  Median={median}, p05={p05}, p10={p10}, p90={p90}, p95={p95}, avg={average}'
         )

--- a/recirq/benchmarks/rep_rate/rep_rate_calculator.py
+++ b/recirq/benchmarks/rep_rate/rep_rate_calculator.py
@@ -6,7 +6,7 @@
 """
 import random
 import cirq
-import cirq_google as cg
+import cirq.google as cg
 import time
 import sympy
 

--- a/recirq/benchmarks/rep_rate/rep_rate_calculator_test.py
+++ b/recirq/benchmarks/rep_rate/rep_rate_calculator_test.py
@@ -1,0 +1,17 @@
+import cirq
+import cirq_google as cg
+import recirq.benchmarks.rep_rate.rep_rate_calculator as rep_rate
+
+def test_latency_with_simulator():
+    tester = rep_rate.RepRateCalculator(
+        project_id='test_project',
+        processor_id='qproc',
+        device=cg.Foxtail,
+        sampler=cirq.Simulator()
+    )
+    latencies = tester.get_latency_samples(50)
+    assert len(latencies) == 50
+
+    # All of these samll circuits should finish in less
+    # than 1 second
+    assert all(0.0 < latency < 1.0 for latency in latencies)

--- a/recirq/benchmarks/rep_rate/rep_rate_calculator_test.py
+++ b/recirq/benchmarks/rep_rate/rep_rate_calculator_test.py
@@ -105,3 +105,28 @@ def test_rep_rate_with_simulator():
     assert stats['p95']
     assert stats['p05'] >= stats['p10'] >= stats['Median']
     assert stats['Median'] >= stats['p90'] >= stats['p95']
+
+
+def test_create_rep_rate_circuit():
+  """Testing an internal method to make sure that the circuit
+  construction is correct.
+  """
+  tester = rep_rate.RepRateCalculator(project_id='test_project',
+                                        processor_id='qproc',
+                                        device=cg.Foxtail,
+                                        sampler=cirq.Simulator())
+  circuit, sweep = tester._create_rep_rate_circuit(False, width=11, depth=14, num_sweeps=1)
+  # 14 layers plus one moment for measurement
+  assert len(circuit)==15
+  assert len(circuit.all_qubits())==11
+  assert sweep is None
+
+  latencies = tester.get_samples(circuit, 7)
+  assert len(latencies) == 7
+
+  circuit, sweep = tester._create_rep_rate_circuit(True, width=2, depth=4, num_sweeps=3)
+  # 14 layers plus one moment for measurement
+  assert len(circuit)==5
+  assert len(circuit.all_qubits())==2
+  assert len(sweep) == 3
+

--- a/recirq/benchmarks/rep_rate/rep_rate_calculator_test.py
+++ b/recirq/benchmarks/rep_rate/rep_rate_calculator_test.py
@@ -1,17 +1,107 @@
+import re
+from typing import Dict
+
 import cirq
 import cirq_google as cg
 import recirq.benchmarks.rep_rate.rep_rate_calculator as rep_rate
 
+
+def _get_stats_from_print_line(s) -> Dict[str, str]:
+    """Retrieves the statistics from the rep rate calculator output.
+
+    Line should look like:
+      'Latency, Median=xxx, p05=xxx, p10=xxx, p90=xxx, p95=xxx'
+
+    Returns a dictionary of stat (e.g. 'Median') to value.
+    """
+    fields = re.split('[,:] *', s)
+    stats_dict = {}
+    for field in fields:
+        key_value = re.split(' ?= ?', field)
+        if len(key_value) >= 2:
+            stats_dict[key_value[0]] = float(key_value[1])
+    return stats_dict
+
+
 def test_latency_with_simulator():
-    tester = rep_rate.RepRateCalculator(
-        project_id='test_project',
-        processor_id='qproc',
-        device=cg.Foxtail,
-        sampler=cirq.Simulator()
-    )
+    tester = rep_rate.RepRateCalculator(project_id='test_project',
+                                        processor_id='qproc',
+                                        device=cg.Foxtail,
+                                        sampler=cirq.Simulator())
     latencies = tester.get_latency_samples(50)
     assert len(latencies) == 50
 
     # All of these samll circuits should finish in less
     # than 1 second
     assert all(0.0 < latency < 1.0 for latency in latencies)
+
+    tester.print_latency(30)
+    # Assuring that print statements are correct
+    # Modify if print behavior changes
+    for n in range(30):
+        assert f'Executing Trial {n}' in tester.print_log
+        assert f'Finished Trial {n}' in tester.print_log
+    lines = tester.print_log.split('\n')
+    latency_line = None
+    for line in lines:
+        if 'Latency' in line:
+            latency_line = line
+    assert latency_line
+
+    stats = _get_stats_from_print_line(latency_line)
+    assert stats['Median']
+    assert stats['p05']
+    assert stats['p10']
+    assert stats['p90']
+    assert stats['p95']
+    assert stats['p05'] <= stats['p10'] <= stats['Median']
+    assert stats['Median'] <= stats['p90'] <= stats['p95']
+
+
+def test_rep_rate_with_simulator():
+    tester = rep_rate.RepRateCalculator(project_id='test_project',
+                                        processor_id='qproc',
+                                        device=cg.Foxtail,
+                                        sampler=cirq.Simulator())
+    tester.print_rep_rate(parameterized=True,
+                          width=8,
+                          depth=8,
+                          num_sweeps=7,
+                          repetitions=2000,
+                          num_trials=10,
+                          subtract_latency=0.0)
+
+    # Assuring that print statements are correct
+    # Modify if print behavior changes
+    for n in range(6):
+        assert f'Executing Trial {n}' in tester.print_log
+        assert f'Finished Trial {n}' in tester.print_log
+
+    lines = tester.print_log.split('\n')
+    latency_line = None
+    rep_rate_line = None
+    for line in lines:
+        if 'Latency' in line:
+            latency_line = line
+        if 'Rep Rate' in line:
+            rep_rate_line = line
+    assert latency_line
+    assert rep_rate_line
+
+    stats = _get_stats_from_print_line(latency_line)
+    assert stats['Median']
+    assert stats['p05']
+    assert stats['p10']
+    assert stats['p90']
+    assert stats['p95']
+    assert stats['p05'] <= stats['p10'] <= stats['Median']
+    assert stats['Median'] <= stats['p90'] <= stats['p95']
+
+    stats = _get_stats_from_print_line(rep_rate_line)
+    assert stats['Median']
+    assert stats['p05']
+    assert stats['p10']
+    assert stats['p90']
+    assert stats['p95']
+    assert stats['p05'] >= stats['p10'] >= stats['Median']
+    assert stats['Median'] >= stats['p90'] >= stats['p95']

--- a/recirq/benchmarks/rep_rate/rep_rate_calculator_test.py
+++ b/recirq/benchmarks/rep_rate/rep_rate_calculator_test.py
@@ -2,7 +2,7 @@ import re
 from typing import Dict
 
 import cirq
-import cirq_google as cg
+import cirq.google as cg
 import recirq.benchmarks.rep_rate.rep_rate_calculator as rep_rate
 
 

--- a/recirq/benchmarks/rep_rate/rep_rate_calculator_test.py
+++ b/recirq/benchmarks/rep_rate/rep_rate_calculator_test.py
@@ -24,10 +24,9 @@ def _get_stats_from_print_line(s) -> Dict[str, str]:
 
 
 def test_latency_with_simulator():
-    tester = rep_rate.RepRateCalculator(project_id='test_project',
-                                        processor_id='qproc',
-                                        device=cg.Foxtail,
-                                        sampler=cirq.Simulator())
+    tester = rep_rate.RepRateCalculator(device=cg.Foxtail,
+                                        sampler=cirq.Simulator(),
+                                        gate=cirq.ISWAP**0.5)
     latencies = tester.get_latency_samples(50)
     assert len(latencies) == 50
 
@@ -59,10 +58,9 @@ def test_latency_with_simulator():
 
 
 def test_rep_rate_with_simulator():
-    tester = rep_rate.RepRateCalculator(project_id='test_project',
-                                        processor_id='qproc',
-                                        device=cg.Foxtail,
-                                        sampler=cirq.Simulator())
+    tester = rep_rate.RepRateCalculator(device=cg.Foxtail,
+                                        sampler=cirq.Simulator(),
+                                        gate=cirq.ISWAP**0.5)
     tester.print_rep_rate(parameterized=True,
                           width=8,
                           depth=8,
@@ -108,25 +106,23 @@ def test_rep_rate_with_simulator():
 
 
 def test_create_rep_rate_circuit():
-  """Testing an internal method to make sure that the circuit
+    """Testing an internal method to make sure that the circuit
   construction is correct.
   """
-  tester = rep_rate.RepRateCalculator(project_id='test_project',
-                                        processor_id='qproc',
-                                        device=cg.Foxtail,
-                                        sampler=cirq.Simulator())
-  circuit, sweep = tester._create_rep_rate_circuit(False, width=11, depth=14, num_sweeps=1)
-  # 14 layers plus one moment for measurement
-  assert len(circuit)==15
-  assert len(circuit.all_qubits())==11
-  assert sweep is None
+    circuit, sweep = rep_rate._create_rep_rate_circuit(
+        False,
+        cirq.ISWAP,
+        qubits=cirq.GridQubit.rect(11, 1),
+        depth=14,
+        num_sweeps=1)
+    # 14 layers plus one moment for measurement
+    assert len(circuit) == 15
+    assert len(circuit.all_qubits()) == 11
+    assert sweep is None
 
-  latencies = tester.get_samples(circuit, 7)
-  assert len(latencies) == 7
-
-  circuit, sweep = tester._create_rep_rate_circuit(True, width=2, depth=4, num_sweeps=3)
-  # 14 layers plus one moment for measurement
-  assert len(circuit)==5
-  assert len(circuit.all_qubits())==2
-  assert len(sweep) == 3
-
+    circuit, sweep = rep_rate._create_rep_rate_circuit(
+        True, cirq.CZ, qubits=cirq.GridQubit.rect(1, 2), depth=4, num_sweeps=3)
+    # 4 layers plus one moment for measurement
+    assert len(circuit) == 5
+    assert len(circuit.all_qubits()) == 2
+    assert len(sweep) == 3


### PR DESCRIPTION
Adds a new module for benchmarks in ReCirq in which the only one is currently the rep rate calculator.

This class will take parameters specifying the size of the circuit (num_sweeps, width, depth, etc) and measure the latency of the circuit when sending to the service.  This will create repetition rate statistics (number of repetitions executed per seconds).

This class is used to generate repetition rate statistics for the processor data sheets.