### PR TITLE
Updated link to OpenFermion 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This code leverages [Cirq](https://github.com/quantumlib/Cirq) as a
 quantum programming language and SDK.
 For those interested in using quantum computers to solve problems in
 chemistry and materials science, please see
-[OpenFermion-Cirq](https://github.com/quantumlib/openfermion-cirq)
+[OpenFermion](https://github.com/quantumlib/openfermion)
 
 
 ReCirq is not an official Google product. Copyright 2020 Google.


### PR DESCRIPTION
The readme contained link to OpenFermion-Cirq, which is now archived and corresponding functionality has been merged to OpenFermion. This PR fixes the link.