### PR TITLE
pin versions of tket

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ scikit-learn
 
 # qaoa
 networkx
-pytket~=0.8
-pytket-cirq~=0.8
+pytket~=0.8.0
+pytket-cirq~=0.8.0
 
 # quantum chess, only needed for tests
 scipy


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0440/#compatible-release

It looks like in future versions this has been replaced with the BackendInfo class (https://cqcl.github.io/pytket/build/html/changelog.html?highlight=device)