### PR TITLE
Make quantum board more automation-friendly

### DIFF
--- a/recirq/quantum_chess/experiments/interactive_board.py
+++ b/recirq/quantum_chess/experiments/interactive_board.py
@@ -60,6 +60,7 @@ def main_loop(args):
             in_str = in_str + ':JUMP:BASIC'
         in_move = m.Move.from_string(in_str)
         meas = b.apply(in_move)
+        print(b.board.circuit)
         b.board.print_debug_log()
         print(f'Measurement outcome = {meas}')
         print('')

--- a/recirq/quantum_chess/quantum_board.py
+++ b/recirq/quantum_chess/quantum_board.py
@@ -167,12 +167,34 @@ class CirqBoard:
         self.debug_log += (f"{action} takes {t1 - t0:0.4f} seconds.\n")
         self.timing_stats[action].append(t1 - t0)
 
-    def sample_with_ancilla(self, num_samples: int
-                            ) -> Tuple[List[int], List[Dict[str, int]]]:
+    def suggest_num_reps(self, sample_size: int) -> int:
+        """Guess the number of raw samples needed to get sample_size results.
+
+        Assume that each post-selection is about 50/50.
+        Noise and error mitigation will discard reps, so increase the total
+        number of repetitions to compensate.
+        """
+        if len(self.post_selection) > 1:
+            sample_size *= 2 ** (len(self.post_selection) + 1)
+        if self.error_mitigation == enums.ErrorMitigation.Correct:
+            sample_size *= 2
+        if self.noise_mitigation > 0:
+            sample_size *= 3
+        if sample_size < 100:
+            sample_size = 100
+        return sample_size
+
+    def sample_with_ancilla(
+            self,
+            num_samples: int,
+            num_reps: Optional[int] = None,
+    ) -> Tuple[List[int], List[Dict[str, int]]]:
         """Samples the board and returns square and ancilla measurements.
 
         Sends the current circuit to the sampler then retrieves the results.
-        May return less samples than num_samples due to post-selection.
+        May return less samples than num_samples due to post-selection. The
+        number of raw results from the sampler is determined by num_reps if
+        provided, or automatically otherwise.
 
         Returns the results as a tuple.  The first entry is the list of
         measured squares, as represented by a 64-bit int bitboard.
@@ -180,6 +202,8 @@ class CirqBoard:
         dictionary from ancilla name to value (0 or 1).
         """
         t0 = time.perf_counter()
+        if num_reps is None:
+            num_reps = self.suggest_num_reps(num_samples)
         measure_circuit = self.circuit.copy()
         ancilla = []
         error_count = 0
@@ -191,21 +215,7 @@ class CirqBoard:
                 cirq.measure(q, key=q.name) for q in qubits)
             measure_circuit.append(measure_moment)
 
-            # Try to guess the appropriate number of repetitions needed
-            # Assume that each post_selection is about 50/50
-            # Noise and error mitigation will discard reps, so increase
-            # the total number of repetitions to compensate
-            if len(self.post_selection) > 1:
-                num_reps = num_samples * (2 ** (len(self.post_selection) + 1))
-            else:
-                num_reps = num_samples
-            if self.error_mitigation == enums.ErrorMitigation.Correct:
-                num_reps *= 2
             noise_threshold = self.noise_mitigation * num_samples
-            if self.noise_mitigation > 0:
-                num_reps *= 3
-            if num_reps < 100:
-                num_reps = 100
 
             self.debug_log += (f'Running circuit with {num_reps} reps '
                                f'to get {num_samples} samples:\n'

--- a/recirq/quantum_chess/quantum_board.py
+++ b/recirq/quantum_chess/quantum_board.py
@@ -218,8 +218,7 @@ class CirqBoard:
             noise_threshold = self.noise_mitigation * num_samples
 
             self.debug_log += (f'Running circuit with {num_reps} reps '
-                               f'to get {num_samples} samples:\n'
-                               f'{str(measure_circuit)}\n')
+                               f'to get {num_samples} samples\n')
 
             # Translate circuit to grid qubits and sqrtISWAP gates
             if self.device is not None:


### PR DESCRIPTION
Some tweaks I need for the fidelity testing script.

- Avoid slow ascii art rendering
- Let the user fully control the number of samples when needed