### PR TITLE
Quantum chess bug fixes

### DIFF
--- a/recirq/quantum_chess/circuit_transformer_test.py
+++ b/recirq/quantum_chess/circuit_transformer_test.py
@@ -175,6 +175,15 @@ def test_too_many_qubits():
         t.transform(c)
 
 
+def test_two_operations_on_single_qubit():
+    """Tests that a new qubit is NOT allocated for every gate."""
+    qubit = cirq.NamedQubit('a')
+    c = cirq.Circuit(*[cirq.X(qubit)] * 99)
+    device = cirq.google.Sycamore23
+    t = ct.ConnectivityHeuristicCircuitTransformer(device)
+    device.validate_circuit(t.transform(c))
+
+
 def test_sycamore_decomposer_reject_0_controlled():
     c = cirq.Circuit(cirq.X(a1).controlled_by(a2, control_values=[0]))
     decomposer = ct.SycamoreDecomposer()

--- a/recirq/quantum_chess/experiments/interactive_board.py
+++ b/recirq/quantum_chess/experiments/interactive_board.py
@@ -50,6 +50,7 @@ def main_loop(args):
     else:
         b.reset()
     print(b)
+    b.board.clear_debug_log()
     for in_str in sys.stdin:
         in_str = in_str.strip()
         if in_str == 'exit':

--- a/recirq/quantum_chess/move.py
+++ b/recirq/quantum_chess/move.py
@@ -65,7 +65,9 @@ class Move:
 
     def __eq__(self, other):
         if isinstance(other, Move):
-            return (self.source == other.source and self.target == other.target
+            return (self.source == other.source
+                    and self.source2 == other.source2
+                    and self.target == other.target
                     and self.target2 == other.target2
                     and self.move_type == other.move_type
                     and self.move_variant == other.move_variant

--- a/recirq/quantum_chess/move_test.py
+++ b/recirq/quantum_chess/move_test.py
@@ -17,6 +17,10 @@ import recirq.quantum_chess.enums as enums
 
 def test_equality():
     assert Move('a1', 'b4') == Move('a1', 'b4')
+    assert (Move(source='g3', source2='c3', target='e4', move_type=enums.MoveType.MERGE_JUMP) ==
+            Move(source='g3', source2='c3', target='e4', move_type=enums.MoveType.MERGE_JUMP))
+    assert (Move(source='g3', source2='c3', target='e4', move_type=enums.MoveType.MERGE_JUMP) !=
+            Move(source='g3', source2='d6', target='e4', move_type=enums.MoveType.MERGE_JUMP))
     assert Move('a1', 'b4') != Move('a1', 'b5')
     assert Move('a1', 'b4') != "a1b4"
 


### PR DESCRIPTION
1. Fix equality test for `Move`
2. In the interactive board, don't log measurement statistics about the initial position
3. Fix a bug where a qubit with only single-qubit gates can be mapped to multiple grid qubits 