### PR TITLE
Add init files to recirq.benchmarks

### DIFF
--- a/recirq/benchmarks/__init__.py
+++ b/recirq/benchmarks/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/recirq/benchmarks/rep_rate/__init__.py
+++ b/recirq/benchmarks/rep_rate/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from recirq.benchmarks.rep_rate.rep_rate_calculator import RepRateCalculator


### PR DESCRIPTION
- Noticed that you could not use the rep rate calculator from
outside recirq, so added the init files so that recirq.benchmarks
would be properly noted as a package.