### PR TITLE
Run pytest actions only on recirq subdirectories that were modified by a pull request

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,6 +28,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.head_ref }}
+
+    - name: Add PR base ref
+      run: git fetch --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
@@ -54,7 +59,7 @@ jobs:
     - name: Test modified subdirectories with pytest
       if: github.event_name == 'pull_request'
       # RECIRQ_CHESS_TEST_SEED: make quantum_chess tests deterministic
-      run: RECIRQ_CHESS_TEST_SEED=789 python dev_tools/pytest_modified.py ${{ github.event.pull_request.base.sha }} -v
+      run: RECIRQ_CHESS_TEST_SEED=789 python dev_tools/pytest_modified.py ${{ github.base_ref }} -v
 
     - name: Test with pytest
       if: github.event_name != 'pull_request' || github.event.pull_request.merged == 'true'

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -48,11 +48,18 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
+    - name: Install pytest
+      run: pip install pytest
+
+    - name: Test modified subdirectories with pytest
+      if: github.event_name == 'pull_request'
+      # RECIRQ_CHESS_TEST_SEED: make quantum_chess tests deterministic
+      run: RECIRQ_CHESS_TEST_SEED=789 dev_tools/pytest_modified.py -v
+
     - name: Test with pytest
-      run: |
-        pip install pytest
-        # RECIRQ_CHESS_TEST_SEED: make quantum_chess tests determnistic
-        RECIRQ_CHESS_TEST_SEED=789 pytest -v
+      if: github.event_name != 'pull_request' || github.event.pull_request.merged == 'true'
+      # RECIRQ_CHESS_TEST_SEED: make quantum_chess tests deterministic
+      run: RECIRQ_CHESS_TEST_SEED=789 pytest -v
 
   nbformat:
     name: Notebook formatting

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Test modified subdirectories with pytest
       if: github.event_name == 'pull_request'
       # RECIRQ_CHESS_TEST_SEED: make quantum_chess tests deterministic
-      run: RECIRQ_CHESS_TEST_SEED=789 dev_tools/pytest_modified.py -v
+      run: RECIRQ_CHESS_TEST_SEED=789 python dev_tools/pytest_modified.py -v
 
     - name: Test with pytest
       if: github.event_name != 'pull_request' || github.event.pull_request.merged == 'true'

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Test modified subdirectories with pytest
       if: github.event_name == 'pull_request'
       # RECIRQ_CHESS_TEST_SEED: make quantum_chess tests deterministic
-      run: RECIRQ_CHESS_TEST_SEED=789 python dev_tools/pytest_modified.py ${{ github.event.pull_request.base.ref }} -v
+      run: RECIRQ_CHESS_TEST_SEED=789 python dev_tools/pytest_modified.py ${{ github.event.pull_request.base.sha }} -v
 
     - name: Test with pytest
       if: github.event_name != 'pull_request' || github.event.pull_request.merged == 'true'

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Test modified subdirectories with pytest
       if: github.event_name == 'pull_request'
       # RECIRQ_CHESS_TEST_SEED: make quantum_chess tests deterministic
-      run: RECIRQ_CHESS_TEST_SEED=789 python dev_tools/pytest_modified.py ${{ github.base_ref }} -v
+      run: RECIRQ_CHESS_TEST_SEED=789 python dev_tools/pytest_modified.py refs/remotes/origin/${{github.base_ref}} -v
 
     - name: Test with pytest
       if: github.event_name != 'pull_request' || github.event.pull_request.merged == 'true'

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Test modified subdirectories with pytest
       if: github.event_name == 'pull_request'
       # RECIRQ_CHESS_TEST_SEED: make quantum_chess tests deterministic
-      run: RECIRQ_CHESS_TEST_SEED=789 python dev_tools/pytest_modified.py -v
+      run: RECIRQ_CHESS_TEST_SEED=789 python dev_tools/pytest_modified.py ${{ github.event.pull_request.base.ref }} -v
 
     - name: Test with pytest
       if: github.event_name != 'pull_request' || github.event.pull_request.merged == 'true'

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,9 +31,6 @@ jobs:
       with:
         ref: ${{ github.head_ref }}
 
-    - name: Add PR base ref
-      run: git fetch --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -56,14 +53,17 @@ jobs:
     - name: Install pytest
       run: pip install pytest
 
-    - name: Test modified subdirectories with pytest
+    - name: Test PR modified subdirectories with pytest
       if: github.event_name == 'pull_request'
-      # RECIRQ_CHESS_TEST_SEED: make quantum_chess tests deterministic
-      run: RECIRQ_CHESS_TEST_SEED=789 python dev_tools/pytest_modified.py refs/remotes/origin/${{github.base_ref}} -v
+      run: |
+        # Ensure the base ref has been fetched locally.
+        git fetch --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
+        # RECIRQ_CHESS_TEST_SEED: make quantum_chess tests deterministic.
+        RECIRQ_CHESS_TEST_SEED=789 python dev_tools/pytest_modified.py refs/remotes/origin/${{github.base_ref}} -v
 
     - name: Test with pytest
       if: github.event_name != 'pull_request' || github.event.pull_request.merged == 'true'
-      # RECIRQ_CHESS_TEST_SEED: make quantum_chess tests deterministic
+      # RECIRQ_CHESS_TEST_SEED: make quantum_chess tests deterministic.
       run: RECIRQ_CHESS_TEST_SEED=789 pytest -v
 
   nbformat:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,8 +28,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.head_ref }}
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1

--- a/dev_tools/pytest_modified.py
+++ b/dev_tools/pytest_modified.py
@@ -3,34 +3,50 @@ import pytest
 import sys
 
 from pathlib import Path
+from typing import List
 
 
-def get_subdir_for_pytest(path):
-  if len(path.parts) >= 3 and path.parts[0] == 'recirq':
-    # path is something inside of one of the subdirectories under 'recirq/'
-    # return the top-level subdirectory inside of 'recirq'
-    # For example, if path is 'recirq/foo/bar.txt' return 'recirq/foo'.
-    return str(Path(*path.parts[0:2]))
-  if len(path.parts) == 2 and path.parts[0] == 'recirq':
-    # path is something inside 'recirq', ex 'recirq/foo.txt'.
-    # Conservatively assume all 'recirq' code may depend on the changes and run
-    # all recirq pytests.
-    return 'recirq'
-  # path is something else not under the 'recirq' subdirectory.
-  # Conservatively assume we should run all pytests.
-  return '.'
+def get_subdir_for_pytest(path: Path) -> str:
+    """Returns the subdir to be pytest'd when a file is modified.
+
+    Args:
+      path: the Path object for the modified file
+    Returns:
+      the subdirectory path prefix string
+    """
+    if len(path.parts) >= 3 and path.parts[0] == "recirq":
+        # path is something inside of one of the subdirectories under 'recirq/'
+        # return the top-level subdirectory inside of 'recirq'
+        # For example, if path is 'recirq/foo/bar.txt' return 'recirq/foo'.
+        return str(Path(*path.parts[0:2]))
+    if len(path.parts) == 2 and path.parts[0] == "recirq":
+        # path is something inside 'recirq', ex 'recirq/foo.txt'.
+        # Conservatively assume all 'recirq' code may depend on the changes and run
+        # all recirq pytests.
+        return "recirq"
+    # path is something else not under the 'recirq' subdirectory.
+    # Conservatively assume we should run all pytests.
+    return "."
 
 
-def get_modified_subdirs():
-  repo = git.Repo()
-  modified_paths = list(Path(item.a_path) for item in repo.index.diff('HEAD'))
-  modified_dirs = set(get_subdir_for_pytest(f) for f in modified_paths)
-  return list(modified_dirs)
+def get_modified_subdirs_for_pytest(repo_path: str) -> List[str]:
+    """Returns subdirectories for pytesting that contain git modifications.
+
+    Args:
+      repo_path: path to the git repository which will be examined for diffs
+    Returns:
+      a (possibly empty) list of subdirectory strings containing modifications
+    """
+    repo = git.Repo(repo_path)
+    modified_paths = list(Path(item.a_path) for item in repo.index.diff("HEAD"))
+    modified_dirs = set(get_subdir_for_pytest(f) for f in modified_paths)
+    return list(modified_dirs)
 
 
 if __name__ == "__main__":
-  modified_subdirs = get_modified_subdirs()
-  if modified_subdirs:
-    pytest_args = modified_subdirs + sys.argv[1:]
-    print("executing pytest with args: " + ",".join(pytest_args))
-    sys.exit(pytest.main(pytest_args))
+    modified_subdirs = get_modified_subdirs_for_pytest(".")
+    if modified_subdirs:
+        # Allow passing through additional argv to pytest.
+        pytest_args = modified_subdirs + sys.argv[1:]
+        print(f"executing pytest with args: [{', '.join(pytest_args)}]")
+        sys.exit(pytest.main(pytest_args))

--- a/dev_tools/pytest_modified.py
+++ b/dev_tools/pytest_modified.py
@@ -3,7 +3,7 @@ import pytest
 import sys
 
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 
 def get_subdir_for_pytest(path: Path) -> str:
@@ -30,7 +30,7 @@ def get_subdir_for_pytest(path: Path) -> str:
 
 
 def get_modified_subdirs_for_pytest(
-    repo_path: str = ".", base_sha: Optional[str] = None
+    repo_path: str = ".", base_ref: str = "HEAD"
 ) -> List[str]:
     """Returns subdirectories for pytesting that contain git modifications.
 
@@ -41,14 +41,14 @@ def get_modified_subdirs_for_pytest(
       a (possibly empty) list of subdirectory strings containing modifications
     """
     repo = git.Repo(repo_path)
-    modified_paths = list(Path(item.a_path) for item in repo.index.diff(base_sha or "HEAD"))
+    modified_paths = list(Path(item.a_path) for item in repo.index.diff(base_ref))
     modified_dirs = set(get_subdir_for_pytest(f) for f in modified_paths)
     return list(modified_dirs)
 
 
 if __name__ == "__main__":
-    base_sha, extra_argv = sys.argv[1], sys.argv[2:]
-    modified_subdirs = get_modified_subdirs_for_pytest(base_sha=base_sha)
+    base_ref, extra_argv = sys.argv[1], sys.argv[2:]
+    modified_subdirs = get_modified_subdirs_for_pytest(base_ref=base_ref)
     if modified_subdirs:
         # Allow passing through additional argv to pytest.
         pytest_args = modified_subdirs + extra_argv

--- a/dev_tools/pytest_modified.py
+++ b/dev_tools/pytest_modified.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import git
 import pytest
 import sys

--- a/dev_tools/pytest_modified.py
+++ b/dev_tools/pytest_modified.py
@@ -10,7 +10,7 @@ def get_subdir_for_pytest(path):
     # path is something inside of one of the subdirectories under 'recirq/'
     # return the top-level subdirectory inside of 'recirq'
     # For example, if path is 'recirq/foo/bar.txt' return 'recirq/foo'.
-    return str(Path(path.parts[0:2]))
+    return str(Path(*path.parts[0:2]))
   if len(path.parts) == 2 and path.parts[0] == 'recirq':
     # path is something inside 'recirq', ex 'recirq/foo.txt'.
     # Conservatively assume all 'recirq' code may depend on the changes and run

--- a/dev_tools/pytest_modified.py
+++ b/dev_tools/pytest_modified.py
@@ -1,0 +1,36 @@
+import git
+import pytest
+import sys
+
+from pathlib import Path
+
+
+def get_subdir_for_pytest(path):
+  if len(path.parts) >= 3 and path.parts[0] == 'recirq':
+    # path is something inside of one of the subdirectories under 'recirq/'
+    # return the top-level subdirectory inside of 'recirq'
+    # For example, if path is 'recirq/foo/bar.txt' return 'recirq/foo'.
+    return str(Path(path.parts[0:2]))
+  if len(path.parts) == 2 and path.parts[0] == 'recirq':
+    # path is something inside 'recirq', ex 'recirq/foo.txt'.
+    # Conservatively assume all 'recirq' code may depend on the changes and run
+    # all recirq pytests.
+    return 'recirq'
+  # path is something else not under the 'recirq' subdirectory.
+  # Conservatively assume we should run all pytests.
+  return '.'
+
+
+def get_modified_subdirs():
+  repo = git.Repo()
+  modified_paths = list(Path(item.a_path) for item in repo.index.diff('HEAD'))
+  modified_dirs = set(get_subdir_for_pytest(f) for f in modified_paths)
+  return list(modified_dirs)
+
+
+if __name__ == "__main__":
+  modified_subdirs = get_modified_subdirs()
+  if modified_subdirs:
+    pytest_args = modified_subdirs + sys.argv[1:]
+    print("executing pytest with args: " + ",".join(pytest_args))
+    sys.exit(pytest.main(pytest_args))

--- a/dev_tools/pytest_modified.py
+++ b/dev_tools/pytest_modified.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import git
 import pytest
 import sys

--- a/dev_tools/pytest_modified.py
+++ b/dev_tools/pytest_modified.py
@@ -29,24 +29,28 @@ def get_subdir_for_pytest(path: Path) -> str:
     return "."
 
 
-def get_modified_subdirs_for_pytest(repo_path: str) -> List[str]:
+def get_modified_subdirs_for_pytest(
+    repo_path: str = ".", base_ref: str = "HEAD"
+) -> List[str]:
     """Returns subdirectories for pytesting that contain git modifications.
 
     Args:
       repo_path: path to the git repository which will be examined for diffs
+      base_ref: the base ref to diff against
     Returns:
       a (possibly empty) list of subdirectory strings containing modifications
     """
     repo = git.Repo(repo_path)
-    modified_paths = list(Path(item.a_path) for item in repo.index.diff("HEAD"))
+    modified_paths = list(Path(item.a_path) for item in repo.index.diff(base_ref))
     modified_dirs = set(get_subdir_for_pytest(f) for f in modified_paths)
     return list(modified_dirs)
 
 
 if __name__ == "__main__":
-    modified_subdirs = get_modified_subdirs_for_pytest(".")
+    base_ref, extra_argv = sys.argv[1], sys.argv[2:]
+    modified_subdirs = get_modified_subdirs_for_pytest(base_ref=base_ref)
     if modified_subdirs:
         # Allow passing through additional argv to pytest.
-        pytest_args = modified_subdirs + sys.argv[1:]
+        pytest_args = modified_subdirs + extra_argv
         print(f"executing pytest with args: [{', '.join(pytest_args)}]")
         sys.exit(pytest.main(pytest_args))

--- a/dev_tools/pytest_modified.py
+++ b/dev_tools/pytest_modified.py
@@ -3,7 +3,7 @@ import pytest
 import sys
 
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 
 def get_subdir_for_pytest(path: Path) -> str:
@@ -30,7 +30,7 @@ def get_subdir_for_pytest(path: Path) -> str:
 
 
 def get_modified_subdirs_for_pytest(
-    repo_path: str = ".", base_ref: str = "HEAD"
+    repo_path: str = ".", base_sha: Optional[str] = None
 ) -> List[str]:
     """Returns subdirectories for pytesting that contain git modifications.
 
@@ -41,14 +41,14 @@ def get_modified_subdirs_for_pytest(
       a (possibly empty) list of subdirectory strings containing modifications
     """
     repo = git.Repo(repo_path)
-    modified_paths = list(Path(item.a_path) for item in repo.index.diff(base_ref))
+    modified_paths = list(Path(item.a_path) for item in repo.index.diff(base_sha or "HEAD"))
     modified_dirs = set(get_subdir_for_pytest(f) for f in modified_paths)
     return list(modified_dirs)
 
 
 if __name__ == "__main__":
-    base_ref, extra_argv = sys.argv[1], sys.argv[2:]
-    modified_subdirs = get_modified_subdirs_for_pytest(base_ref=base_ref)
+    base_sha, extra_argv = sys.argv[1], sys.argv[2:]
+    modified_subdirs = get_modified_subdirs_for_pytest(base_sha=base_sha)
     if modified_subdirs:
         # Allow passing through additional argv to pytest.
         pytest_args = modified_subdirs + extra_argv

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ seaborn
 sphinx
 ipython
 black
+gitpython
 
 # optimize
 scikit-learn


### PR DESCRIPTION
On PR events:

- inspect the files modified by the PR
- collect the subdirectories containing those files
- run pytest only on those subdirectories

Most changes which only affect one of the experiments under a directory within `recirq/` will trigger pytest on that experiment's subdirectory. However for paths that are likely to affect the entire repo, we'd still pytest everything.

I tested this by creating some PRs against my fork, ex: https://github.com/weinstein/ReCirq/pull/2
and examining the actions that ran for the PR events: https://github.com/weinstein/ReCirq/runs/3930186853
as well as the push event: https://github.com/weinstein/ReCirq/runs/3911613649

With these changes, we'd still run the original action and pytest the entire repo after a PR gets merged. However, this won't actually prevent merging if those tests fail, and github doesn't expose any "pre-merge attempt" events that we could potentially trigger the actions on. One potential workaround would be to require review on all PRs (in addition to the currently required statuses) and trigger the final expensive round of testing on PR review completion.