### PR TITLE
Toffoli is no longer a controlled operation in cirq 0.13

### DIFF
--- a/recirq/quantum_chess/circuit_transformer.py
+++ b/recirq/quantum_chess/circuit_transformer.py
@@ -413,9 +413,7 @@ class SycamoreDecomposer(cirq.PointOptimizer):
         if len(op.qubits) > 3:
             raise DeviceMappingError(f"Four qubit ops not yet supported: {op}")
         new_ops = None
-        if op.gate == cirq.SWAP or op.gate == cirq.CNOT:
-            new_ops = cirq.google.optimized_for_sycamore(cirq.Circuit(op))
-        elif op.gate == cirq.TOFFOLI:
+        if op.gate == cirq.SWAP or op.gate == cirq.CNOT or op.gate == cirq.TOFFOLI:
             new_ops = cirq.google.optimized_for_sycamore(cirq.Circuit(op))
         elif isinstance(op, cirq.ControlledOperation):
             if not all(v == 1 for values in op.control_values for v in values):


### PR DESCRIPTION
- Handle Toffoli separately in quantum chess so that it is
    decomposed correctly.
- See https://github.com/quantumlib/Cirq/pull/4167
- Part of the upgrade effort to cirq 0.13 #224 

Thanks to @mpharrigan for tracking down and proposing a fix for this.