### PR TITLE
Remove use_cache arguments

### DIFF
--- a/recirq/quantum_chess/caching_utils.py
+++ b/recirq/quantum_chess/caching_utils.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Tuple
 import recirq.quantum_chess.enums as enums
 import recirq.quantum_chess.move as move
 
@@ -11,3 +12,20 @@ class CacheKey:
 
 def cache_key_from_move(m: move.Move, repetitions: int) -> CacheKey:
     return CacheKey(m.move_type, repetitions)
+
+
+@dataclass(frozen=True)
+class ProbabilityHistory:
+    """Stores square occupancy histogram for a point in the move history.
+
+    Args:
+        repetitions: number of samples used to generate probabilities
+        probabilities: maps square -> probability of being occupied
+        full_squares: (derived from self.probabilities) full squares bitboard
+        empty_squares: (derived from self.probabilities) empty squares bitboard
+    """
+
+    repetitions: int
+    probabilities: Tuple[float, ...]  # for each square
+    full_squares: int  # bitboard derived from square_probabilities
+    empty_squares: int  # bitboard derived from square_probabilities

--- a/recirq/quantum_chess/move.py
+++ b/recirq/quantum_chess/move.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import recirq.quantum_chess.enums as enums
+from typing import Optional
 
 _ORD_A = ord("a")
 
@@ -52,11 +53,11 @@ class Move:
         source: str,
         target: str,
         *,
-        source2: str = None,
-        target2: str = None,
-        move_type: enums.MoveType = None,
-        move_variant: enums.MoveVariant = None,
-        measurement: int = None,
+        source2: Optional[str] = None,
+        target2: Optional[str] = None,
+        move_type: Optional[enums.MoveType] = None,
+        move_variant: Optional[enums.MoveVariant] = None,
+        measurement: Optional[int] = None,
     ):
         self.source = source
         self.source2 = source2

--- a/recirq/quantum_chess/quantum_board.py
+++ b/recirq/quantum_chess/quantum_board.py
@@ -97,13 +97,14 @@ class CirqBoard:
         self.error_mitigation = error_mitigation
         self.noise_mitigation = noise_mitigation
 
-        # None if there is no cache, stores the repetition number if there is a cache.
-        self.board_accumulations_repetitions = None
+        # Stores the repetition number if there is a cache.
+        self.board_accumulations_repetitions = -1
+
         self.cache = {}
 
     def with_state(self, basis_state: int) -> "CirqBoard":
         """Resets the board with a specific classical state."""
-        self.board_accumulations_repetitions = None
+        self.board_accumulations_repetitions = -1
         self.state = basis_state
         self.allowed_pieces = set()
         self.allowed_pieces.add(num_ones(self.state))
@@ -489,7 +490,7 @@ class CirqBoard:
 
         The values are returned as a dict{bitboard(int): prob(float)}.
         """
-        if self.board_accumulations_repetitions != repetitions:
+        if self.board_accumulations_repetitions < repetitions:
             self._generate_board_accumulations(repetitions)
 
         return self.board_probabilities
@@ -704,7 +705,7 @@ class CirqBoard:
             raise ValueError("Move type is unspecified")
 
         # Reset accumulations here because function has conditional return branches
-        self.board_accumulations_repetitions = None
+        self.board_accumulations_repetitions = -1
 
         # Add move to move_history
         self.move_history.append(m)

--- a/recirq/quantum_chess/quantum_board.py
+++ b/recirq/quantum_chess/quantum_board.py
@@ -672,7 +672,7 @@ class CirqBoard:
         qubit: cirq.Qid,
         measurement_outcome: Optional[int] = None,
         invert: Optional[bool] = False,
-    ) -> bool:
+    ) -> int:
         """Adds a post-selection requirement to the circuit.
 
         If no measurement_outcome is provided, performs a single sample of the

--- a/recirq/quantum_chess/quantum_board_test.py
+++ b/recirq/quantum_chess/quantum_board_test.py
@@ -1256,7 +1256,7 @@ def test_get_probability_distribution_split_jump_pre_cached(board):
         move_variant=enums.MoveVariant.BASIC,
     )
     b.do_move(m1)
-    probs = b.get_probability_distribution(100)
+    probs = list(b.get_probability_distribution(100))
     b.do_move(m2)
     b.clear_debug_log()
     # Expected probability with the cache applied
@@ -1265,11 +1265,11 @@ def test_get_probability_distribution_split_jump_pre_cached(board):
     probs[square_to_bit("d1")] = b.cache[cache_key]["target2"]
 
     # Get probability distribution should apply the cache without rerunning _generate_accumulations.
-    probs2 = b.get_probability_distribution(100, use_cache=True)
-    full_squares = b.get_full_squares_bitboard(100, use_cache=True)
-    empty_squares = b.get_empty_squares_bitboard(100, use_cache=True)
+    probs2 = b.get_probability_distribution(100)
+    full_squares = b.get_full_squares_bitboard(100)
+    empty_squares = b.get_empty_squares_bitboard(100)
 
-    assert probs == probs2
+    assert tuple(probs) == probs2
     # Check that the second run and getting full and empty bitboards did not trigger any new logs.
     assert len(b.debug_log) == 0
     # Check bitboard updated correctly
@@ -1302,11 +1302,11 @@ def test_get_probability_distribution_split_jump_first_move_pre_cached(board):
     expected_probs[square_to_bit("d1")] = b.cache[cache_key]["target2"]
 
     # Get probability distribution should apply the cache without rerunning _generate_accumulations.
-    probs = b.get_probability_distribution(100, use_cache=True)
-    full_squares = b.get_full_squares_bitboard(100, use_cache=True)
-    empty_squares = b.get_empty_squares_bitboard(100, use_cache=True)
+    probs = b.get_probability_distribution(100)
+    full_squares = b.get_full_squares_bitboard(100)
+    empty_squares = b.get_empty_squares_bitboard(100)
 
-    assert probs == expected_probs
+    assert probs == tuple(expected_probs)
     # Check that the second run and getting full and empty bitboards did not trigger any new logs.
     assert len(b.debug_log) == 0
     # Check bitboard updated correctly

--- a/recirq/quantum_chess/swap_updater.py
+++ b/recirq/quantum_chess/swap_updater.py
@@ -106,7 +106,7 @@ class SwapUpdater:
         device_qubits: Optional[Iterable[cirq.GridQubit]],
         initial_mapping: Dict[cirq.Qid, cirq.GridQubit] = {},
         swap_factory: Callable[
-            [cirq.Qid, cirq.Qid], List[cirq.Operation]
+            [cirq.Qid, cirq.Qid], Iterable[cirq.Operation]
         ] = generate_decomposed_swap,
     ):
         self.device_qubits = device_qubits


### PR DESCRIPTION
We discussed making 'use cache' a class property, but actually the pre-cached move feature can't do anything anyway, unless you feed it with cached moves. So it seems unnecessary to a have a switch turning it off at all - just don't feed it with pre-cached moves. (See commit message for more details).