### PR TITLE
Add function for 2-qubit tomography

### DIFF
--- a/recirq/quantum_chess/experiments/interactive_board.py
+++ b/recirq/quantum_chess/experiments/interactive_board.py
@@ -55,6 +55,12 @@ def main_loop(args):
         in_str = in_str.strip()
         if in_str == "exit":
             return
+        elif in_str.startswith("density"):
+            _, square1, square2 = in_str.split()
+            density = b.board.two_square_density_matrix(square1, square2, 2000).data
+            b.board.print_debug_log()
+            print(density.round(3))
+            continue
         if not in_str:
             continue
         if ":" not in in_str:

--- a/recirq/quantum_chess/experiments/interactive_board.py
+++ b/recirq/quantum_chess/experiments/interactive_board.py
@@ -37,7 +37,10 @@ Examples:
 The interactive board uses a simulator with an unconstrained device.
 """
 import argparse
+import math
 import sys
+
+import numpy as np
 
 import recirq.quantum_chess.ascii_board as ab
 import recirq.quantum_chess.move as m
@@ -60,6 +63,8 @@ def main_loop(args):
             density = b.board.two_square_density_matrix(square1, square2, 2000).data
             b.board.print_debug_log()
             print(density.round(3))
+            transposed = density.reshape(2, 2, 2, 2).transpose(0, 3, 2, 1).reshape(4, 4)
+            print("Log negativity:", math.log2(np.linalg.norm(transposed, "nuc")))
             continue
         if not in_str:
             continue


### PR DESCRIPTION
two_square_density_matrix() gives the density matrix for any pair of
squares.

This requires running 9 variants of the circuit with different gates at
the end tweaking the two qubits of interest.

Error correction and noise mitigation are disabled, since the qubits
undergoing tomography can't be measured in the computational basis.

The density matrix can be viewed from interactive_board.py with the
command, e.g., `density f3 f5`.

---

Before merging I'd want to remove some of the duplicated code between the new function and `sample_with_ancilla`.