### PR TITLE
Move requirements into subpackages

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install --no-deps -e .
+        pip install -e .
 
     - name: Lint with flake8
       run: |

--- a/recirq/fermi_hubbard/extra-requirements.txt
+++ b/recirq/fermi_hubbard/extra-requirements.txt
@@ -1,0 +1,1 @@
+openfermion

--- a/recirq/hfvqe/extra-requirements.txt
+++ b/recirq/hfvqe/extra-requirements.txt
@@ -1,0 +1,3 @@
+# fix bug with openfermionpyscf https://github.com/quantumlib/ReCirq/issues/200#issuecomment-923203883
+h5py~=3.2.1
+openfermion~=1.2.0

--- a/recirq/optimize/extra-requirements.txt
+++ b/recirq/optimize/extra-requirements.txt
@@ -1,0 +1,1 @@
+scikit-learn

--- a/recirq/otoc/extra-requirements.txt
+++ b/recirq/otoc/extra-requirements.txt
@@ -1,0 +1,1 @@
+Py-BOBYQA

--- a/recirq/qaoa/extra-requirements.txt
+++ b/recirq/qaoa/extra-requirements.txt
@@ -1,0 +1,1 @@
+pytket-cirq~=0.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,24 +8,3 @@ seaborn
 sphinx
 ipython
 black
-
-# optimize
-scikit-learn
-
-# qaoa
-networkx
-pytket-cirq~=0.16.0
-
-# quantum chess, only needed for tests
-scipy
-
-# hfvqe
-openfermion~=1.2.0
-# fix bug with openfermionpyscf https://github.com/quantumlib/ReCirq/issues/200#issuecomment-923203883
-h5py~=3.2.1
-
-# fermi_hubbard
-tqdm  # notebook progress bars
-
-# otoc
-Py-BOBYQA

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ extras_require = {
     for r in extras_require
 }
 
-# TODO: remove and require users to install via extras_require.
+# TODO(gh-231): remove and require users to install via extras_require.
 install_requires = functools.reduce(operator.add, extras_require.values(), install_requires)
 
 setup(name='recirq',

--- a/setup.py
+++ b/setup.py
@@ -13,22 +13,41 @@
 # limitations under the License.
 
 import pathlib
+import functools
+import operator
+
 from setuptools import find_packages, setup
 
 __version__ = ''
 exec(open('recirq/_version.py').read())
 assert __version__, 'Version string cannot be empty'
 
-required_packages = pathlib.Path('requirements.txt').read_text().split('\n')
-INSTALL_PACKAGES = [pkg for pkg in required_packages if pkg and not pkg.startswith('#')]
+
+def _parse_requirements(path: pathlib.Path):
+    lines = [line.strip() for line in path.read_text().splitlines() if line]
+    return [line for line in lines if not line.startswith('#')]
+
+
+install_requires = _parse_requirements(pathlib.Path('requirements.txt'))
+extras_require = [
+    'otoc', 'qaoa', 'optimize', 'hfvqe', 'fermi_hubbard'
+]
+extras_require = {
+    r: _parse_requirements(pathlib.Path(f'recirq/{r}/extra-requirements.txt'))
+    for r in extras_require
+}
+
+# TODO: remove and require users to install via extras_require.
+install_requires = functools.reduce(operator.add, extras_require.values(), install_requires)
 
 setup(name='recirq',
       version=__version__,
-      url='http://github.com/quantumlib/cirq',
-      author='The Cirq Developers',
+      url='http://github.com/quantumlib/recirq',
+      author='Quantum AI team and collaborators',
       author_email='cirq@googlegroups.com',
       python_requires='>=3.6.0',
-      install_requires=INSTALL_PACKAGES,
+      install_requires=install_requires,
+      extras_require=extras_require,
       license='Apache 2',
       description="",
       long_description=open('README.md', encoding='utf-8').read(),


### PR DESCRIPTION
 - `extra-requirements.txt` per subpackage
 - Right now: union all the extra requirements into `install_requires` and add `extra_requires` for each subpackage (setup.py)
 - Next: modify notebooks to install using e.g. `recirq[qaoa]`. Remove extra requires from `install_requires`. This stepwise change is necessary since the notebooks install from github #231
 - Next: independent test jobs for subpackages to make sure the requirements are correct.

Annotated change:
```
# optimize
scikit-learn  # (moved to extra-requires)

# qaoa
networkx   # (transitive from cirq-core)
pytket-cirq~=0.16.0   # (moved to extra-requires)

# quantum chess, only needed for tests
scipy    # (transitive from cirq-core, test requirements shouldn't be here)

# hfvqe
openfermion~=1.2.0    # (moved to extra-requires)
# fix bug with openfermionpyscf https://github.com/quantumlib/ReCirq/issues/200#issuecomment-923203883
h5py~=3.2.1   # (moved to extra-requires)

# fermi_hubbard
tqdm  # notebook progress bars (transitive from cirq-core)

# otoc
Py-BOBYQA   # (moved to extra-requires)
```