### PR TITLE
loschmidt.tilted_square_lattice Benchmark

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,7 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cirq-version: [ 'previous', 'current', 'next' ]
+        cirq-version:
+          - 'current'
+          # - 'previous'  (gh-247: Disabled 2012-12-15 for cirq.NamedTopologies)
+          - 'next'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/recirq/algorithmic_benchmark_library.py
+++ b/recirq/algorithmic_benchmark_library.py
@@ -5,6 +5,11 @@ from typing import Type, Callable, List, Tuple, Any
 
 import pandas as pd
 
+from recirq.otoc.loschmidt.tilted_square_lattice import (
+    TiltedSquareLatticeLoschmidtSpec,
+    get_all_tilted_square_lattice_executables,
+)
+
 try:
     from cirq_google.workflow import ExecutableSpec, QuantumExecutableGroup
 
@@ -32,7 +37,6 @@ class AlgorithmicBenchmark:
             The executable family is the fully-qualified leaf-module where the code
             for this AlgorithmicBenchmark lives.
         spec_class: The ExecutableSpec subclass for this AlgorithmicBenchmark.
-        data_class: The class which can contain ETL-ed data for this AlgorithmicBenchmark.
         executable_generator_func: The function that returns a QuantumExecutableGroup for a
             given Config.
         configs: A list of available `BenchmarkConfig` for this benchmark.
@@ -42,7 +46,6 @@ class AlgorithmicBenchmark:
     name: str
     executable_family: str
     spec_class: Type['ExecutableSpec']
-    data_class: Type
     executable_generator_func: Callable[[Any], 'QuantumExecutableGroup']
     configs: List['BenchmarkConfig']
 
@@ -50,7 +53,6 @@ class AlgorithmicBenchmark:
         """Get values of this class as strings suitable for printing."""
         ret = {k: str(v) for k, v in dataclasses.asdict(self).items()}
         ret['spec_class'] = self.spec_class.__name__
-        ret['data_class'] = self.data_class.__name__
         ret['executable_generator_func'] = self.executable_generator_func.__name__
         return ret
 
@@ -74,6 +76,15 @@ class BenchmarkConfig:
 
 
 BENCHMARKS = [
+    AlgorithmicBenchmark(
+        domain='recirq.otoc',
+        name='loschmidt.tilted_square_lattice',
+        executable_family='recirq.otoc.loschmidt.tilted_square_lattice',
+        spec_class=TiltedSquareLatticeLoschmidtSpec,
+        executable_generator_func=get_all_tilted_square_lattice_executables,
+        configs=[
+        ]
+    ),
 ]
 
 

--- a/recirq/algorithmic_benchmark_library_test.py
+++ b/recirq/algorithmic_benchmark_library_test.py
@@ -49,8 +49,6 @@ def test_classes_and_funcs(algo):
     mod = import_module(algo.executable_family)
     assert algo.spec_class == getattr(mod, algo.spec_class.__name__), \
         "The spec_class must exist in the benchmark's module"
-    assert algo.data_class == getattr(mod, algo.data_class.__name__), \
-        "The data_class must exist in the benchmark's module"
     assert algo.executable_generator_func == getattr(mod, algo.executable_generator_func.__name__), \
         "the executable_generator_func must exist in the benchmark's module"
 

--- a/recirq/otoc/loschmidt/__init__.py
+++ b/recirq/otoc/loschmidt/__init__.py
@@ -1,0 +1,34 @@
+# Copyright 2021 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from functools import lru_cache
+from typing import Optional
+
+from cirq.protocols.json_serialization import ObjectFactory, DEFAULT_RESOLVERS
+from .tilted_square_lattice import (
+    TiltedSquareLatticeLoschmidtSpec,
+)
+
+
+@lru_cache()
+def _resolve_json(cirq_type: str) -> Optional[ObjectFactory]:
+    if not cirq_type.startswith('recirq.otoc.'):
+        return None
+
+    cirq_type = cirq_type[len('recirq.otoc.'):]
+    return {k.__name__: k for k in [
+        TiltedSquareLatticeLoschmidtSpec,
+    ]}.get(cirq_type, None)
+
+
+DEFAULT_RESOLVERS.append(_resolve_json)

--- a/recirq/otoc/loschmidt/__init__.py
+++ b/recirq/otoc/loschmidt/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google
+# Copyright 2022 Google
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recirq/otoc/loschmidt/tilted_square_lattice/__init__.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/__init__.py
@@ -1,0 +1,1 @@
+from .tilted_square_lattice import *

--- a/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice.py
@@ -1,0 +1,146 @@
+import itertools
+from dataclasses import dataclass
+
+import numpy as np
+
+import cirq
+from cirq import TiltedSquareLattice
+from cirq.experiments import random_rotations_between_grid_interaction_layers_circuit
+from cirq.protocols import dataclass_json_dict
+from cirq_google.workflow import QuantumExecutable, BitstringsMeasurement, QuantumExecutableGroup, \
+    ExecutableSpec
+
+
+def create_tilted_square_lattice_loschmidt_echo_circuit(
+        topology: TiltedSquareLattice,
+        macrocycle_depth: int,
+        twoq_gate: cirq.Gate = cirq.FSimGate(np.pi / 4, 0.0),
+        rs: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
+) -> cirq.FrozenCircuit:
+    """Returns a Loschmidt echo circuit using a random unitary U.
+
+    Args:
+        topology: The TiltedSquareLattice topology.
+        macrocycle_depth: Number of complete, macrocycles in the random unitary. A macrocycle is
+            4 cycles corresponding to the 4 grid directions. Each cycle is one layer of entangling
+            gates and one layer of random single qubit rotations. The total circuit depth is
+            twice as large because we also do the inverse.
+        twoq_gate: Two-qubit gate to use.
+        rs: The random state for random circuit generation.
+    """
+
+    # Forward (U) operations.
+    exponents = np.linspace(0, 7 / 4, 8)
+    single_qubit_gates = [
+        cirq.PhasedXZGate(x_exponent=0.5, z_exponent=z, axis_phase_exponent=a)
+        for a, z in itertools.product(exponents, repeat=2)
+    ]
+    qubits = sorted(topology.nodes_as_gridqubits())
+    forward = random_rotations_between_grid_interaction_layers_circuit(
+        # note: this function should take a topology probably.
+        qubits=qubits,
+        # note: in this function, `depth` refers to cycles.
+        depth=4 * macrocycle_depth,
+        two_qubit_op_factory=lambda a, b, _: twoq_gate.on(a, b),
+        pattern=cirq.experiments.GRID_STAGGERED_PATTERN,
+        single_qubit_gates=single_qubit_gates,
+        seed=rs
+    )
+
+    # Reverse (U^\dagger) operations.
+    reverse = cirq.inverse(forward)
+
+    return (forward + reverse + cirq.measure(*qubits, key='z')).freeze()
+
+
+def _get_all_tilted_square_lattices(min_side_length=2, max_side_length=8, side_length_step=2):
+    """Helper function to get a range of tilted square lattices."""
+    width_heights = np.arange(min_side_length, max_side_length + 1, side_length_step)
+    return [TiltedSquareLattice(width, height)
+            for width, height in itertools.combinations_with_replacement(width_heights, r=2)]
+
+
+@dataclass(frozen=True)
+class TiltedSquareLatticeLoschmidtSpec(ExecutableSpec):
+    """The ExecutableSpec for the tilted square lattice loschmidt benchmark.
+
+    The loschmidt echo runs a random unitary forward and backwards and measures how often
+    we return to the starting state.
+
+    Args:
+        topology: The topology
+        macrocycle_depth: Number of complete, macrocycles in the random unitary. A macrocycle is
+            4 cycles corresponding to the 4 grid directions. Each cycle is one layer of entangling
+            gates and one layer of random single qubit rotations. The total circuit depth is
+            twice as large because we also do the inverse.
+        instance_i: An arbitary index into the random instantiation
+        n_repetitions: The number of repetitions to sample to measure the return probability.
+        executable_family: The globally unique string identifier for this benchmark.
+    """
+
+    topology: TiltedSquareLattice
+    macrocycle_depth: int
+    instance_i: int
+    n_repetitions: int
+    executable_family: str = 'recirq.otoc.loschmidt.tilted_square_lattice'
+
+    @classmethod
+    def _json_namespace_(cls):
+        return 'recirq.otoc'
+
+    def _json_dict_(self):
+        return dataclass_json_dict(self)
+
+
+def get_all_tilted_square_lattice_executables(
+        *, n_instances=10, n_repetitions=1_000,
+        min_side_length=2, max_side_length=8,
+        side_length_step=2,
+        macrocycle_depths=None, seed=52,
+) -> QuantumExecutableGroup:
+    """Return a collection of quantum executables for various parameter settings of the tilted
+    square lattice loschmidt benchmark.
+
+    Args:
+        n_instances: The number of random instances to make per setting
+        n_repetitions: The number of circuit repetitions to use for measuring the return
+            probability.
+        min_side_length, max_side_length, side_length_step: generate a range of
+            TiltedSquareLattice topologies with widths and heights in this range.
+        seed: The random seed to make this deterministic.
+        macrocycle_depths: The collection of macrocycle depths to use per setting.
+    """
+
+    rs = np.random.RandomState(seed)
+    if macrocycle_depths is None:
+        macrocycle_depths = np.arange(2, 8 + 1, 2)
+    topologies = _get_all_tilted_square_lattices(
+        min_side_length=min_side_length,
+        max_side_length=max_side_length,
+        side_length_step=side_length_step,
+    )
+
+    specs = [
+        TiltedSquareLatticeLoschmidtSpec(
+            topology=topology,
+            macrocycle_depth=macrocycle_depth,
+            instance_i=instance_i,
+            n_repetitions=n_repetitions
+        )
+        for topology, macrocycle_depth, instance_i in itertools.product(
+            topologies, macrocycle_depths, range(n_instances))
+    ]
+
+    return QuantumExecutableGroup([
+        QuantumExecutable(
+            spec=spec,
+            problem_topology=spec.topology,
+            circuit=create_tilted_square_lattice_loschmidt_echo_circuit(
+                topology=spec.topology,
+                macrocycle_depth=spec.macrocycle_depth,
+                rs=rs,
+            ),
+            measurement=BitstringsMeasurement(spec.n_repetitions)
+        )
+        for spec in specs
+    ])

--- a/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice.py
@@ -90,7 +90,7 @@ class TiltedSquareLatticeLoschmidtSpec(ExecutableSpec):
         return 'recirq.otoc'
 
     def _json_dict_(self):
-        return dataclass_json_dict(self)
+        return dataclass_json_dict(self, namespace=self._json_namespace_())
 
 
 def get_all_tilted_square_lattice_executables(

--- a/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice.py
@@ -65,7 +65,8 @@ class TiltedSquareLatticeLoschmidtSpec(ExecutableSpec):
     """The ExecutableSpec for the tilted square lattice loschmidt benchmark.
 
     The loschmidt echo runs a random unitary forward and backwards and measures how often
-    we return to the starting state.
+    we return to the starting state. This benchmark checks random unitaries generated
+    on the TiltedSquareLattice topology.
 
     Args:
         topology: The topology

--- a/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google
+# Copyright 2022 Google
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice_test.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice_test.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+import cirq
+# Need this exact import for monkeypatching to work (below)
+import recirq.otoc.loschmidt.tilted_square_lattice.tilted_square_lattice
+from recirq.otoc.loschmidt.tilted_square_lattice import \
+    create_tilted_square_lattice_loschmidt_echo_circuit, TiltedSquareLatticeLoschmidtSpec, \
+    get_all_tilted_square_lattice_executables
+
+
+def test_create_tilted_square_lattice_loschmidt_echo_circuit():
+    topology = cirq.TiltedSquareLattice(width=3, height=2)
+    macrocycle_depth = 2
+    circuit = create_tilted_square_lattice_loschmidt_echo_circuit(
+        topology=topology, macrocycle_depth=macrocycle_depth, rs=np.random.RandomState(52)
+    )
+    assert isinstance(circuit, cirq.FrozenCircuit)
+
+    assert len(circuit.all_qubits()) == topology.n_nodes
+    assert sorted(circuit.all_qubits()) == sorted(topology.nodes_as_gridqubits())
+
+    edge_coloring_n = 4  # grid
+    forward_backward = 2
+    n_moment_per_microcycle = 2  # layer of single- and two- qubit gate
+    measure_moment = 1
+    extra_single_q_layer = 1
+    assert len(circuit) == (edge_coloring_n * macrocycle_depth *
+                            n_moment_per_microcycle + extra_single_q_layer) \
+           * forward_backward + measure_moment
+
+
+def test_tilted_square_lattice_loschmidt_spec(tmpdir):
+    topology = cirq.TiltedSquareLattice(width=3, height=2)
+    macrocycle_depth = 2
+    spec1 = TiltedSquareLatticeLoschmidtSpec(
+        topology=topology,
+        macrocycle_depth=macrocycle_depth,
+        instance_i=0,
+        n_repetitions=10_000,
+    )
+    assert spec1.executable_family == 'recirq.otoc.loschmidt.tilted_square_lattice'
+
+    fn = f'{tmpdir}/spec.json'
+    cirq.to_json(spec1, fn)
+    spec2 = cirq.read_json(fn)
+    assert spec1 == spec2
+
+
+def test_get_all_tilted_square_lattice_executables(monkeypatch):
+    call_count = 0
+
+    def mock_get_circuit(topology: cirq.TiltedSquareLattice, macrocycle_depth: int,
+                         twoq_gate: cirq.Gate = cirq.FSimGate(np.pi / 4, 0.0),
+                         rs: cirq.RANDOM_STATE_OR_SEED_LIKE = None):
+        nonlocal call_count
+        call_count += 1
+        return cirq.Circuit()
+
+    monkeypatch.setattr(recirq.otoc.loschmidt.tilted_square_lattice.tilted_square_lattice,
+                        "create_tilted_square_lattice_loschmidt_echo_circuit", mock_get_circuit)
+    get_all_tilted_square_lattice_executables()
+    n_instances = 10
+    n_macrocycle_depths = 4  # 2,4,6,8
+    n_side_lengths = 4  # width or height # of possibilities
+    n_topos = n_side_lengths * (n_side_lengths + 1) / 2
+    assert call_count == n_instances * n_macrocycle_depths * n_topos

--- a/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice_test.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice_test.py
@@ -49,6 +49,9 @@ def test_tilted_square_lattice_loschmidt_spec(tmpdir):
 def test_get_all_tilted_square_lattice_executables(monkeypatch):
     call_count = 0
 
+    # Creating random circuits is expensive, but this test tests the default arguments for
+    # this function and asserts that it's called the correct number of times.
+
     def mock_get_circuit(topology: cirq.TiltedSquareLattice, macrocycle_depth: int,
                          twoq_gate: cirq.Gate = cirq.FSimGate(np.pi / 4, 0.0),
                          rs: cirq.RANDOM_STATE_OR_SEED_LIKE = None):

--- a/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice_test.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice_test.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google
+# Copyright 2022 Google
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adds the executable generation functionality for the following benchmark:

```python
AlgorithmicBenchmark(
    domain='recirq.otoc',
    name='loschmidt.tilted_square_lattice',
    executable_family='recirq.otoc.loschmidt.tilted_square_lattice',
    spec_class=TiltedSquareLatticeLoschmidtSpec,
    executable_generator_func=get_all_tilted_square_lattice_executables,
)
```

The loschmidt echo runs a random unitary forward and backwards and measures how often we return to the starting state. This benchmark checks random unitaries generated on the TiltedSquareLattice topology.

### Notes

This PR does not include any BenchmarkConfig's, namely scripts for launching execution and analysis.

I've also removed the `data_class` field from the AlgorithmicBenchmark card catalog. (1) I don't want to make this PR too big by including it (2) I want to work some of the kinks out of the design of the data analysis part of the flow without holding up committing the infrastructure for taking data. 


## Cirq requirements

Following #237 , this will only test the new functionality against the pre-release version of cirq where the `cirq_google.workflow` utilities are available.

I've noticed as well that Cirq 0.12 does **not** include `cirq.NamedTopology`. This is a case where keeping compatibility with the prior version of Cirq is **not** worth it, esp. since v0.13 has been out for a while. As part of this PR I've disabled the "pre" check with a note. We'll re-enable when Cirq 0.14 comes out.