### PR TITLE
CI Testing Matrix

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,48 +20,46 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  pytest:
+    name: Pytest
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
-
+        cirq-version: [ 'previous', 'current', 'next' ]
+      fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python dev_tools/write-ci-requirements.py --relative-cirq-version=${{ matrix.cirq-version }} --all-extras
+          pip install -r ci-requirements.txt
+          pip install --no-deps -e .
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Lint with flake8
+        run: |
+          pip install flake8
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -e .
-
-    - name: Lint with flake8
-      run: |
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-
-    - name: Test with pytest
-      run: |
-        pip install pytest
-        # RECIRQ_CHESS_TEST_SEED: make quantum_chess tests determnistic
-        RECIRQ_CHESS_TEST_SEED=789 pytest -v
-
+      - name: Test with pytest
+        run: |
+          pip install pytest
+          # RECIRQ_CHESS_TEST_SEED: make quantum_chess tests determnistic
+          # RECIRQ_IGNORE_PYTKET: for 'next' cirq version, skip pytket tests
+          RECIRQ_CHESS_TEST_SEED=789 RECIRQ_IGNORE_PYTKET=y pytest -v
   nbformat:
     name: Notebook formatting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
-          architecture: 'x64'
+          python-version: '3.9'
       - name: Doc check
         run: dev_tools/nbfmt

--- a/dev_tools/write-ci-requirements.py
+++ b/dev_tools/write-ci-requirements.py
@@ -1,0 +1,107 @@
+import pathlib
+import re
+import sys
+from argparse import ArgumentParser
+from typing import Any, Dict, List
+
+REPO_DIR = pathlib.Path(__file__).parent.parent.resolve()
+print('Repo dir:', REPO_DIR)
+
+CIRQ_VERSIONS = {
+    'previous': '==0.12.0',
+    'current': '==0.13.0',
+    'next': '>=0.14.0.dev',
+}
+"""Give names to relative Cirq versions so CI can have consistent names while versions 
+get incremented."""
+
+
+def _parse_requirements(path: pathlib.Path):
+    """Read and strip comments from a requirements.txt-like file. """
+    lines = [line.strip() for line in path.read_text().splitlines() if line]
+    return [line for line in lines if not line.startswith('#')]
+
+
+def _remove_version_spec(req: str) -> str:
+    """Remove a version specifier like ==1.3 from a requirements.txt line."""
+    components = re.split(r'>=|~=|<=|==', req)
+    return components[0]
+
+
+def _set_cirq_version(core_reqs: List[str], relative_cirq_version: str) -> List[str]:
+    """Return a new version of `core_reqs` that pins cirq-like packages to the desired version."""
+    cirq_version = CIRQ_VERSIONS[relative_cirq_version]
+    to_change = 'cirq', 'cirq-google', 'cirq-core'
+
+    new_reqs = []
+    for req in core_reqs:
+        without_spec = _remove_version_spec(req)
+        if without_spec in to_change:
+            new_reqs.append(f'{without_spec}{cirq_version}')
+        else:
+            new_reqs.append(req)
+
+    return new_reqs
+
+
+def _set_qaoa_hacks(qaoa_reqs: List[str], relative_cirq_version: str) -> List[str]:
+    """Pytket pins to a specific cirq version and doesn't work with cirq "next".
+    """
+    if relative_cirq_version != 'next':
+        return qaoa_reqs
+
+    new_reqs = []
+    for req in qaoa_reqs:
+        without_spec = _remove_version_spec(req)
+        if without_spec == 'pytket-cirq':
+            continue
+        else:
+            new_reqs.append(req)
+
+    return new_reqs
+
+
+def main(*, out_fn: str = 'ci-requirements.txt', relative_cirq_version: str = 'current',
+         all_extras: bool = False):
+    """Write a requirements.txt file for CI installation and testing.
+
+    Args:
+         out_fn: The output filename
+         relative_cirq_version: Pin the desired cirq version to either "current", "previous",
+            or "next" version.
+        all_extras: Whether to include all the extras_require dependencies.
+    """
+    core_reqs = _parse_requirements(REPO_DIR / 'requirements.txt')
+    core_reqs = _set_cirq_version(core_reqs, relative_cirq_version)
+
+    extras_require = [
+        'otoc', 'qaoa', 'optimize', 'hfvqe', 'fermi_hubbard', 'qml_lfe'
+    ]
+    extras_require = {
+        r: _parse_requirements(pathlib.Path(REPO_DIR / f'recirq/{r}/extra-requirements.txt'))
+        for r in extras_require
+    }
+    extras_require['qaoa'] = _set_qaoa_hacks(extras_require['qaoa'], relative_cirq_version)
+
+    lines = ['# Core requirements'] + core_reqs
+    if all_extras:
+        for name, reqs in extras_require.items():
+            lines += ['', f'# {name}']
+            lines += reqs
+    lines += ['']
+
+    out = '\n'.join(lines)
+    sys.stdout.write(out)
+    (REPO_DIR / out_fn).write_text(out)
+
+
+def parse() -> Dict[str, Any]:
+    parser = ArgumentParser()
+    parser.add_argument('--out-fn', default='ci-requirements.txt')
+    parser.add_argument('--relative-cirq-version', default='current')
+    parser.add_argument('--all-extras', action='store_true', default=False)
+    return vars(parser.parse_args())
+
+
+if __name__ == '__main__':
+    main(**parse())

--- a/recirq/fermi_hubbard/extra-requirements.txt
+++ b/recirq/fermi_hubbard/extra-requirements.txt
@@ -1,1 +1,1 @@
-openfermion
+openfermion>=1.2.0

--- a/recirq/hfvqe/extra-requirements.txt
+++ b/recirq/hfvqe/extra-requirements.txt
@@ -1,3 +1,3 @@
 # fix bug with openfermionpyscf https://github.com/quantumlib/ReCirq/issues/200#issuecomment-923203883
 h5py~=3.2.1
-openfermion~=1.2.0
+openfermion>=1.2.0

--- a/recirq/qaoa/extra-requirements.txt
+++ b/recirq/qaoa/extra-requirements.txt
@@ -1,1 +1,1 @@
-pytket-cirq~=0.16.0
+pytket-cirq>=0.16

--- a/recirq/qaoa/placement.py
+++ b/recirq/qaoa/placement.py
@@ -11,6 +11,8 @@ import cirq.contrib.routing as ccr
 import cirq_google as cg
 
 try:
+    # Set the 'RECIRQ_IGNORE_PYTKET' environment variable to treat PyTket as an optional
+    # dependency. We do this for CI testing against the next, pre-release Cirq version.
     import pytket
     import pytket.extensions.cirq
     from pytket.circuit import Node, Qubit

--- a/recirq/qaoa/placement.py
+++ b/recirq/qaoa/placement.py
@@ -3,17 +3,25 @@ from collections import defaultdict
 from functools import lru_cache
 from typing import Callable, Dict, List, Optional, Tuple
 
+import networkx as nx
+import numpy as np
+
 import cirq
 import cirq.contrib.routing as ccr
 import cirq_google as cg
-import networkx as nx
-import numpy as np
-import pytket
-import pytket.extensions.cirq
-from pytket.circuit import Node, Qubit
-from pytket.passes import SequencePass, RoutingPass, PlacementPass
-from pytket.predicates import CompilationUnit, ConnectivityPredicate
-from pytket.routing import GraphPlacement
+
+try:
+    import pytket
+    import pytket.extensions.cirq
+    from pytket.circuit import Node, Qubit
+    from pytket.passes import SequencePass, RoutingPass, PlacementPass
+    from pytket.predicates import CompilationUnit, ConnectivityPredicate
+    from pytket.routing import GraphPlacement
+except ImportError as e:
+    if 'RECIRQ_IGNORE_PYTKET' in os.environ:
+        pytket = NotImplemented
+    else:
+        raise e
 
 import recirq
 
@@ -56,7 +64,7 @@ def _device_to_tket_device(device):
     )
 
 
-def tk_to_cirq_qubit(tk: Qubit):
+def tk_to_cirq_qubit(tk: 'Qubit'):
     """Convert a tket Qubit to either a LineQubit or GridQubit.
 
     """

--- a/recirq/qaoa/placement_test.py
+++ b/recirq/qaoa/placement_test.py
@@ -12,7 +12,7 @@ from recirq.qaoa.gates_and_compilation import compile_problem_unitary_to_arbitra
     compile_driver_unitary_to_rx
 from recirq.qaoa.placement import place_line_on_device, place_on_device, \
     min_weight_simple_paths_brute_force, min_weight_simple_path_greedy, path_weight, \
-    min_weight_simple_path_anneal
+    min_weight_simple_path_anneal, pytket
 from recirq.qaoa.problem_circuits import get_generic_qaoa_circuit
 
 
@@ -23,6 +23,7 @@ def permute_gate(qubits: Sequence[cirq.Qid], permutation: List[int]):
     ).on(*qubits)
 
 
+@pytest.mark.skipif(pytket is NotImplemented, reason='Pytket is not installed.')
 def test_place_on_device():
     problem_graph = nx.random_regular_graph(d=3, n=10)
     nx.set_edge_attributes(problem_graph, values=1, name='weight')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 cirq-core>=0.12.0
 cirq-google>=0.12.0
+# When changing Cirq requirements be sure to update dev_tools/write-ci-requirements.py
+
 seaborn
 sphinx
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
-
-# We'd like to only depend on cirq-core and cirq-google, but pip's dependency resolver
-# chokes since pytket depends on the cirq metapackage.
-cirq~=0.12.0
-cirq-core~=0.12.0
-cirq-google~=0.12.0
+cirq-core>=0.12.0
+cirq-google>=0.12.0
 seaborn
 sphinx
 ipython


### PR DESCRIPTION
## Problem overview

We depend on openfermion, pytket, and pytket-cirq; which have historically been over-pinned to a particular cirq version. "Overpinned" means that even if it seems to work with a newer (or older!) cirq version, the `install_requires` still specifies one version. `pip` has recently (past year) learned to be strict about satisfying requirements. `pip` will end up in an infinite loop downloading old versions instead of saying which package is causing a version deadlock

As a developer, I can get things to work by installing dependencies myself and then `pip install --no-deps` openfermion, cirq, pytket, or recirq so pip can't get in my way.

However, one important use case is supporting colab which must have a simple install script; hopefully just `pip install recirq` (or, specifically, the git url).

## Openfermion relaxation

Cirq has been generally stable across the past couple of releases, especially if one were to go through and fix deprecation warnings. Indeed, I have changed openfermion https://github.com/quantumlib/OpenFermion/pull/755/ to not pin in `install_requires` but to use the CI to test against multiple versions of Cirq.

## Towards relaxing ReCirq

This PR aims to head towards the same goal. We test against the previous, current, and next version of Cirq. Testing against the next version of Cirq is particularly important when committing code that depends on unreleased Cirq features. The trick is to _attempt_ the full matrix of versions, and lean heavily on `pytest.mark.skipif` to make sure tests only run under supported configurations. 

In particular, we introduce a script to capture the intricacies of the various test configurations: `write-ci-requirements.txt`. This lets us pin to a particular cirq version during CI testing but not in `install_requires`, which we change to a lower bound.

This script has several notable features
- translate fixed "relative" versions like current, previous, and next to numeric, pypi ones. Otherwise, the numeric versions from the CI matrix will show up in the job names. We want to set the "required checks" setting on GitHub without having it rely on the current cirq versions, which will change over time
- Hacky pytket logic: don't test the pytket functionality on the next cirq version.

## Cirq 0.13
This fixes #224 because pytket and openfermion have compatible versions now.

## Cirq 0.14
We'll now be in the regime where we need to fix ReCirq for the next Cirq version _before_ it is released. As such, this PR is based off of #241 .

## Per-package testing

This still tests the whole ReCirq repository at once. We can modify `write-ci-requirements.py` to help simplify a new matrix job that tests each subpackage in isolation. `skipif` may be a large component to that as well.
