### PR TITLE
Changes for Cirq 0.14

### DIFF
--- a/docs/fermi_hubbard/experiment_example.ipynb
+++ b/docs/fermi_hubbard/experiment_example.ipynb
@@ -849,9 +849,10 @@
    "source": [
     "\"\"\"Get an engine sampler.\"\"\"\n",
     "import os\n",
+    "import cirq_google\n",
     "\n",
     "if \"GOOGLE_CLOUD_PROJECT\" in os.environ:\n",
-    "    engine_sampler = cirq.google.get_engine_sampler(\n",
+    "    engine_sampler = cirq_google.get_engine_sampler(\n",
     "        processor_id=\"rainbow\", gate_set_name=\"sqrt_iswap\"\n",
     "    )\n",
     "else:\n",

--- a/docs/qaoa/precomputed_analysis.ipynb
+++ b/docs/qaoa/precomputed_analysis.ipynb
@@ -763,7 +763,7 @@
    ],
    "source": [
     "from recirq.qaoa.simulation import hamiltonian_objectives, hamiltonian_objective_avg_and_err\n",
-    "import cirq.google as cg\n",
+    "import cirq_google as cg\n",
     "\n",
     "def compute_energy_w_err(row):\n",
     "    permutation = []\n",

--- a/docs/qaoa/routing_with_tket.ipynb
+++ b/docs/qaoa/routing_with_tket.ipynb
@@ -203,7 +203,7 @@
    },
    "outputs": [],
    "source": [
-    "import cirq.google as cg\n",
+    "import cirq_google as cg\n",
     "\n",
     "dev_graph = ccr.gridqubits_to_graph_device(cg.Sycamore23.qubits)\n",
     "nx.draw_networkx(dev_graph)"

--- a/docs/quantum_chess/concepts.ipynb
+++ b/docs/quantum_chess/concepts.ipynb
@@ -1139,7 +1139,7 @@
     "\n",
     "We will need a more powerful tool.  Let's use the concept of an optimizer.  This is a cirq tool that can run through a circuit, making changes as it goes along.  It can be used for compiling to a specific gate set, compressing circuits into less space, or other useful transformations.\n",
     "\n",
-    "Luckily, one already exists for compiling to $\\sqrt{\\text{iSWAP}}$.  `cirq.google.optimized_for_sycamore`.  Let's first demonstrate this with the CNOT gate:\n"
+    "Luckily, one already exists for compiling to $\\sqrt{\\text{iSWAP}}$.  `cirq_google.optimized_for_sycamore`.  Let's first demonstrate this with the CNOT gate:\n"
    ]
   },
   {
@@ -1150,7 +1150,7 @@
    },
    "outputs": [],
    "source": [
-    "print(cirq.google.optimized_for_sycamore(cirq.Circuit(cirq.CNOT(a1, a2))))"
+    "print(cirq_google.optimized_for_sycamore(cirq.Circuit(cirq.CNOT(a1, a2))))"
    ]
   },
   {
@@ -1174,7 +1174,7 @@
    "source": [
     "c_iswap = cirq.Circuit(cirq.ISWAP(a1, a3).controlled_by(a2))\n",
     "try:\n",
-    "    cirq.google.optimized_for_sycamore(c_iswap, optimizer_type=\"sqrt_iswap\")\n",
+    "    cirq_google.optimized_for_sycamore(c_iswap, optimizer_type=\"sqrt_iswap\")\n",
     "except Exception as e:\n",
     "    print(\"An error occurred while attempting to optimize: \")\n",
     "    print(e)"
@@ -1272,7 +1272,7 @@
    },
    "outputs": [],
    "source": [
-    "decomposed_circuit = cirq.google.optimized_for_sycamore(\n",
+    "decomposed_circuit = cirq_google.optimized_for_sycamore(\n",
     "    c_iswap_decomposed, optimizer_type=\"sqrt_iswap\"\n",
     ")\n",
     "print(f\"Circuit: {len(decomposed_circuit)} moments\")\n",
@@ -1309,7 +1309,7 @@
    },
    "outputs": [],
    "source": [
-    "print(cirq.google.Sycamore)"
+    "print(cirq_google.Sycamore)"
    ]
   },
   {
@@ -1446,7 +1446,7 @@
     "\n",
     "# First, modify the circuit so that ISWAP's become two ISWAP ** 0.5\n",
     "exclusion_move_sycamore = exclusion_with_sqrt_iswaps.with_device(\n",
-    "    new_device=cirq.google.Sycamore, qubit_mapping=qubit_transformer\n",
+    "    new_device=cirq_google.Sycamore, qubit_mapping=qubit_transformer\n",
     ")\n",
     "print(exclusion_move_sycamore)"
    ]
@@ -1616,14 +1616,14 @@
     "\n",
     "dynamic_mapping = qubit_mapping(\n",
     "    exclusion_with_sqrt_iswaps,\n",
-    "    cirq.google.Sycamore,\n",
+    "    cirq_google.Sycamore,\n",
     "    cirq.NamedQubit(\"b1\"),\n",
     "    cirq.GridQubit(3, 5),\n",
     ")\n",
     "for q in dynamic_mapping:\n",
     "    print(f\"Qubit {q} maps to {dynamic_mapping[q]}\")\n",
     "dynamically_mapped_circuit = exclusion_with_sqrt_iswaps.with_device(\n",
-    "    new_device=cirq.google.Sycamore, qubit_mapping=lambda q: dynamic_mapping[q]\n",
+    "    new_device=cirq_google.Sycamore, qubit_mapping=lambda q: dynamic_mapping[q]\n",
     ")\n",
     "print(dynamically_mapped_circuit)"
    ]

--- a/recirq/__init__.py
+++ b/recirq/__init__.py
@@ -36,7 +36,6 @@ from recirq.engine_utils import (
     get_processor_id_by_device_name,
     get_sampler_by_name,
     execute_in_queue,
-    get_available_processors
 )
 
 from recirq.documentation_utils import (

--- a/recirq/benchmarks/rep_rate/rep_rate_calculator.py
+++ b/recirq/benchmarks/rep_rate/rep_rate_calculator.py
@@ -133,12 +133,12 @@ class RepRateCalculator:
                     processor_id: str,
                     gate_set: Optional[cg.SerializableGateSet] = None):
         """
-        Constructs a RepRateTester using a cirq.google.Engine object.
+        Constructs a RepRateTester using a cirq_google.Engine object.
         Uses the device from the device specification from the API
         and the sampler provided by the Engine.
 
         Args:
-            engine: cirq.google.Engine to use for device and sampler.
+            engine: cirq_google.Engine to use for device and sampler.
             gate_set: gate set to use.  Defaults to square root of iswap
             processor_id: Processor to test on.
         """

--- a/recirq/qaoa/placement_test.py
+++ b/recirq/qaoa/placement_test.py
@@ -42,7 +42,7 @@ def test_place_on_device():
     routed_circuit, initial_qubit_map, final_qubit_map = place_on_device(circuit, device)
 
     # Check that constraints are not violated
-    for _, op, _ in routed_circuit.findall_operations_with_gate_type(cirq.TwoQubitGate):
+    for _, op in routed_circuit.findall_operations(lambda op: op._num_qubits_() == 2):
         a, b = op.qubits
         a = cast(cirq.GridQubit, a)
         b = cast(cirq.GridQubit, b)

--- a/recirq/quantum_chess/circuit_transformer.py
+++ b/recirq/quantum_chess/circuit_transformer.py
@@ -15,6 +15,7 @@ import copy
 from typing import Dict, Iterable, List, Optional, Set
 
 import cirq
+import cirq_google as cg
 
 import recirq.quantum_chess.controlled_iswap as controlled_iswap
 import recirq.quantum_chess.initial_mapping_utils as imu
@@ -414,7 +415,7 @@ class SycamoreDecomposer(cirq.PointOptimizer):
             raise DeviceMappingError(f"Four qubit ops not yet supported: {op}")
         new_ops = None
         if op.gate == cirq.SWAP or op.gate == cirq.CNOT or op.gate == cirq.TOFFOLI:
-            new_ops = cirq.google.optimized_for_sycamore(cirq.Circuit(op))
+            new_ops = cg.optimized_for_sycamore(cirq.Circuit(op))
         elif isinstance(op, cirq.ControlledOperation):
             if not all(v == 1 for values in op.control_values for v in values):
                 raise DeviceMappingError(f"0-controlled ops not yet supported: {op}")
@@ -433,11 +434,11 @@ class SycamoreDecomposer(cirq.PointOptimizer):
                 )
             if op.gate.sub_gate == cirq.X:
                 if len(op.qubits) == 2:
-                    new_ops = cirq.google.optimized_for_sycamore(
+                    new_ops = cg.optimized_for_sycamore(
                         cirq.Circuit(cirq.CNOT(*op.controls, *qubits))
                     )
                 if len(op.qubits) == 3:
-                    new_ops = cirq.google.optimized_for_sycamore(
+                    new_ops = cg.optimized_for_sycamore(
                         cirq.Circuit(cirq.TOFFOLI(*op.controls, *qubits))
                     )
         if new_ops:

--- a/recirq/quantum_chess/circuit_transformer_test.py
+++ b/recirq/quantum_chess/circuit_transformer_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import pytest
 import cirq
+import cirq_google as cg
 
 import recirq.quantum_chess.circuit_transformer as ct
 import recirq.quantum_chess.quantum_moves as qm
@@ -30,7 +31,7 @@ c3 = cirq.NamedQubit("c3")
 d1 = cirq.NamedQubit("d1")
 
 
-@pytest.mark.parametrize("device", (cirq.google.Sycamore23, cirq.google.Sycamore))
+@pytest.mark.parametrize("device", (cg.Sycamore23, cg.Sycamore))
 def test_qubits_within(device):
     """Coupling graph of grid qubits looks like:
 
@@ -47,7 +48,7 @@ def test_qubits_within(device):
     assert transformer.qubits_within(10, grid_qubits[0], grid_qubits, set()) == 6
 
 
-@pytest.mark.parametrize("device", (cirq.google.Sycamore23, cirq.google.Sycamore))
+@pytest.mark.parametrize("device", (cg.Sycamore23, cg.Sycamore))
 def test_edges_within(device):
     """
     The circuit looks like:
@@ -93,7 +94,7 @@ def test_edges_within(device):
         ct.DynamicLookAheadHeuristicCircuitTransformer,
     ],
 )
-@pytest.mark.parametrize("device", [cirq.google.Sycamore23, cirq.google.Sycamore])
+@pytest.mark.parametrize("device", [cg.Sycamore23, cg.Sycamore])
 def test_single_qubit_ops(transformer, device):
     c = cirq.Circuit(cirq.X(a1), cirq.X(a2), cirq.X(a3))
     t = transformer(device)
@@ -107,7 +108,7 @@ def test_single_qubit_ops(transformer, device):
         ct.DynamicLookAheadHeuristicCircuitTransformer,
     ],
 )
-@pytest.mark.parametrize("device", [cirq.google.Sycamore23, cirq.google.Sycamore])
+@pytest.mark.parametrize("device", [cg.Sycamore23, cg.Sycamore])
 def test_single_qubit_and_two_qubits_ops(transformer, device):
     c = cirq.Circuit(cirq.X(a1), cirq.X(a2), cirq.X(a3), cirq.ISWAP(a3, a4) ** 0.5)
     t = transformer(device)
@@ -121,7 +122,7 @@ def test_single_qubit_and_two_qubits_ops(transformer, device):
         ct.DynamicLookAheadHeuristicCircuitTransformer,
     ],
 )
-@pytest.mark.parametrize("device", [cirq.google.Sycamore23, cirq.google.Sycamore])
+@pytest.mark.parametrize("device", [cg.Sycamore23, cg.Sycamore])
 def test_three_split_moves(transformer, device):
     c = cirq.Circuit(
         qm.split_move(a1, a2, b1), qm.split_move(a2, a3, b3), qm.split_move(b1, c1, c2)
@@ -137,7 +138,7 @@ def test_three_split_moves(transformer, device):
         ct.DynamicLookAheadHeuristicCircuitTransformer,
     ],
 )
-@pytest.mark.parametrize("device", [cirq.google.Sycamore23, cirq.google.Sycamore])
+@pytest.mark.parametrize("device", [cg.Sycamore23, cg.Sycamore])
 def test_disconnected(transformer, device):
     c = cirq.Circuit(
         qm.split_move(a1, a2, a3),
@@ -156,7 +157,7 @@ def test_disconnected(transformer, device):
         ct.DynamicLookAheadHeuristicCircuitTransformer,
     ],
 )
-@pytest.mark.parametrize("device", [cirq.google.Sycamore23, cirq.google.Sycamore])
+@pytest.mark.parametrize("device", [cg.Sycamore23, cg.Sycamore])
 def test_move_around_square(transformer, device):
     c = cirq.Circuit(
         qm.normal_move(a1, a2),
@@ -175,7 +176,7 @@ def test_move_around_square(transformer, device):
         ct.DynamicLookAheadHeuristicCircuitTransformer,
     ],
 )
-@pytest.mark.parametrize("device", [cirq.google.Sycamore23, cirq.google.Sycamore])
+@pytest.mark.parametrize("device", [cg.Sycamore23, cg.Sycamore])
 def test_split_then_merge(transformer, device):
     c = cirq.Circuit(
         qm.split_move(a1, a2, b1),
@@ -189,7 +190,7 @@ def test_split_then_merge(transformer, device):
     device.validate_circuit(t.transform(c))
 
 
-@pytest.mark.parametrize("device", [cirq.google.Sycamore23, cirq.google.Sycamore])
+@pytest.mark.parametrize("device", [cg.Sycamore23, cg.Sycamore])
 def test_split_then_merge_trapezoid(device):
     c = cirq.Circuit(
         qm.split_move(a1, a2, b1), qm.normal_move(a2, a3), qm.merge_move(a3, b1, b3)
@@ -202,7 +203,7 @@ def test_too_many_qubits():
     c = cirq.Circuit()
     for i in range(24):
         c.append(cirq.X(cirq.NamedQubit("q" + str(i))))
-    t = ct.ConnectivityHeuristicCircuitTransformer(cirq.google.Sycamore23)
+    t = ct.ConnectivityHeuristicCircuitTransformer(cg.Sycamore23)
     with pytest.raises(ct.DeviceMappingError, match="Qubits exhausted"):
         t.transform(c)
 
@@ -211,7 +212,7 @@ def test_two_operations_on_single_qubit():
     """Tests that a new qubit is NOT allocated for every gate."""
     qubit = cirq.NamedQubit("a")
     c = cirq.Circuit(*[cirq.X(qubit)] * 99)
-    device = cirq.google.Sycamore23
+    device = cg.Sycamore23
     t = ct.ConnectivityHeuristicCircuitTransformer(device)
     device.validate_circuit(t.transform(c))
 

--- a/recirq/quantum_chess/controlled_iswap.py
+++ b/recirq/quantum_chess/controlled_iswap.py
@@ -14,6 +14,7 @@
 from typing import Sequence, Union, Optional
 
 import cirq
+import cirq_google as cg
 import numpy as np
 from cirq.optimizers.two_qubit_to_fsim import (
     _decompose_xx_yy_into_two_fsims_ignoring_single_qubit_ops,
@@ -122,7 +123,7 @@ def controlled_iswap(
 
 def controlled_sqrt_iswap(a: cirq.Qid, b: cirq.Qid, c: cirq.Qid):
     """Performs (ISWAP(a,b)i**0.5).controlled_by(c)"""
-    return cirq.google.optimized_for_sycamore(
+    return cg.optimized_for_sycamore(
         cirq.Circuit(
             cirq.CNOT(a, b),
             cirq.TOFFOLI(c, b, a) ** -0.5,
@@ -134,7 +135,7 @@ def controlled_sqrt_iswap(a: cirq.Qid, b: cirq.Qid, c: cirq.Qid):
 
 def controlled_inv_sqrt_iswap(a: cirq.Qid, b: cirq.Qid, c: cirq.Qid):
     """Performs (ISWAP(a,b)i**0.5).controlled_by(c)"""
-    return cirq.google.optimized_for_sycamore(
+    return cg.optimized_for_sycamore(
         cirq.Circuit(
             cirq.CNOT(a, b),
             cirq.TOFFOLI(c, b, a) ** 0.5,

--- a/recirq/quantum_chess/experiments/circuit_transform_benchmark.py
+++ b/recirq/quantum_chess/experiments/circuit_transform_benchmark.py
@@ -30,6 +30,7 @@ directory (https://github.com/quantumlib/ReCirq/issues/163).
 """
 
 import cirq
+import cirq_google as cg
 import cProfile
 import pstats
 import sys
@@ -75,7 +76,7 @@ def optimize(name: str, circuit: cirq.Circuit) -> cirq.Circuit:
     """
     print(f"optimizing: {name}", flush=True)
     start = timer()
-    optimized = cirq.google.optimized_for_sycamore(circuit)
+    optimized = cg.optimized_for_sycamore(circuit)
     stop = timer()
     print_stats(stop - start, optimized)
     return optimized
@@ -127,7 +128,7 @@ def benchmark_transform(
 
 
 def main(input_files: List[str]) -> None:
-    device = cirq.google.Sycamore
+    device = cg.Sycamore
     transformers = {
         "dynamic look-ahead placement": ct.DynamicLookAheadHeuristicCircuitTransformer(
             device

--- a/recirq/quantum_chess/initial_mapping_utils_test.py
+++ b/recirq/quantum_chess/initial_mapping_utils_test.py
@@ -15,6 +15,7 @@ import pytest
 from collections import deque
 
 import cirq
+import cirq_google as cg
 
 import recirq.quantum_chess.initial_mapping_utils as imu
 
@@ -33,7 +34,7 @@ grid_qubits = dict(
 
 
 def test_build_physical_qubits_graph():
-    g = imu.build_physical_qubits_graph(cirq.google.Foxtail)
+    g = imu.build_physical_qubits_graph(cg.Foxtail)
     expected = {
         grid_qubits["0_0"]: [grid_qubits["0_1"], grid_qubits["1_0"]],
         grid_qubits["0_1"]: [
@@ -356,7 +357,7 @@ def test_find_reference_qubits():
 
 
 def test_find_candidate_qubits():
-    g = imu.build_physical_qubits_graph(cirq.google.Foxtail)
+    g = imu.build_physical_qubits_graph(cg.Foxtail)
     # First level has free qubits.
     mapped = {
         grid_qubits["0_5"],
@@ -418,8 +419,8 @@ def test_find_shortest_path():
 @pytest.mark.parametrize(
     "device",
     [
-        cirq.google.Sycamore23,
-        cirq.google.Sycamore,
+        cg.Sycamore23,
+        cg.Sycamore,
     ],
 )
 def test_calculate_initial_mapping(device):

--- a/recirq/quantum_chess/readout_tester_test.py
+++ b/recirq/quantum_chess/readout_tester_test.py
@@ -14,12 +14,13 @@
 #
 #
 import cirq
+import cirq_google as cg
 
 import recirq.quantum_chess.readout_tester as readout_tester
 
 
 def test_readout_tester():
-    device = cirq.google.Sycamore23
+    device = cg.Sycamore23
     sim = cirq.Simulator()
 
     tester = readout_tester.ReadoutTester(sampler=sim, device=device)

--- a/recirq/quantum_chess/swap_updater_test.py
+++ b/recirq/quantum_chess/swap_updater_test.py
@@ -1,5 +1,6 @@
 import pytest
 import cirq
+import cirq_google as cg
 
 from recirq.quantum_chess.swap_updater import SwapUpdater, generate_decomposed_swap
 import recirq.quantum_chess.quantum_moves as qm
@@ -104,7 +105,7 @@ def test_pentagonal_split_and_merge():
 
     # Whereas the original circuit's initial mapping was not valid due to
     # adjacency constraints, the updated circuit is valid.
-    device = cirq.google.Sycamore
+    device = cg.Sycamore
     with pytest.raises(ValueError):
         device.validate_circuit(
             logical_circuit.transform_qubits(lambda q: initial_mapping.get(q))
@@ -172,7 +173,7 @@ def test_holes_in_device_graph():
     updated_circuit = cirq.Circuit(
         SwapUpdater(circuit, allowed_qubits, initial_mapping).add_swaps()
     )
-    cirq.google.Sycamore.validate_circuit(updated_circuit)
+    cg.Sycamore.validate_circuit(updated_circuit)
     for op in updated_circuit.all_operations():
         assert initial_mapping[b2] not in op.qubits
 


### PR DESCRIPTION
- cirq_google
- EngineTimeSlot removal. If this helper function is necessary for quantum chess, please open a follow-on PR to re-enable cc @dstrain115 
- TwoQubitGate removal, used in the tests