### PR TITLE
Fix failing tensorflow.org import job.

### DIFF
--- a/docs/quantum_chess/concepts.ipynb
+++ b/docs/quantum_chess/concepts.ipynb
@@ -127,6 +127,7 @@
    "outputs": [],
    "source": [
     "import cirq\n",
+    "import cirq_google\n",
     "from typing import Dict, Iterable, Optional, Set"
    ]
   },


### PR DESCRIPTION
This notebook uses cirq_google, but forgot to import it.