### PR TITLE
Add dev_tools/check_notebooks.py

### DIFF
--- a/dev_tools/.gitignore
+++ b/dev_tools/.gitignore
@@ -1,0 +1,1 @@
+notebook_envs

--- a/dev_tools/check_notebooks.py
+++ b/dev_tools/check_notebooks.py
@@ -12,11 +12,17 @@ BASE_PACKAGES = [
 ]
 
 
-def _check_notebook(notebook_fn, notebook_id, stdout, stderr):
+def _check_notebook(notebook_fn: str, notebook_id: str, stdout, stderr):
     """Helper function to actually do the work in `check_notebook`.
 
     `check_notebook` has all the context managers and exception handling,
     which would otherwise result in highly indented code.
+
+    Args:
+        notebook_fn: The notebook filename
+        notebook_id: A unique string id for the notebook that does not include `/`
+        stdout: A file-like object to redirect stdout
+        stderr: A file-like object to redirect stderr
     """
     print(f'Starting {notebook_id}')
 
@@ -41,7 +47,7 @@ def _check_notebook(notebook_fn, notebook_id, stdout, stderr):
     shutil.rmtree(venv_dir)
 
 
-def check_notebook(notebook_fn):
+def check_notebook(notebook_fn: str):
     """Check a notebook.
 
      1. Create a venv just for that notebook

--- a/dev_tools/check_notebooks.py
+++ b/dev_tools/check_notebooks.py
@@ -1,0 +1,103 @@
+import os
+import shutil
+import time
+from multiprocessing import Pool
+from subprocess import run as _run, CalledProcessError
+
+BASE_PACKAGES = [
+    # for running the notebooks
+    "jupyter",
+    # assumed to be part of colab
+    "seaborn~=0.11.1",
+]
+
+
+def _check_notebook(notebook_fn, notebook_id, stdout, stderr):
+    """Helper function to actually do the work in `check_notebook`.
+
+    `check_notebook` has all the context managers and exception handling,
+    which would otherwise result in highly indented code.
+    """
+    print(f'Starting {notebook_id}')
+
+    def run(*args, **kwargs):
+        return _run(*args, check=True, stdout=stdout, stderr=stderr, **kwargs)
+
+    # 1. create venv
+    venv_dir = os.path.abspath(f'./notebook_envs/{notebook_id}')
+    run(['python', '-m', 'venv', '--clear', venv_dir])
+
+    # 2. basic colab-like environment
+    pip = f'{venv_dir}/bin/pip'
+    run([pip, 'install'] + BASE_PACKAGES)
+
+    # 3. execute
+    jupyter = f'{venv_dir}/bin/jupyter'
+    env = os.environ.copy()
+    env['PATH'] = f'{venv_dir}/bin:{env["PATH"]}'
+    run([jupyter, 'nbconvert', '--to', 'html', '--execute', notebook_fn], cwd='../', env=env)
+
+    # 4. clean up
+    shutil.rmtree(venv_dir)
+
+
+def check_notebook(notebook_fn):
+    """Check a notebook.
+
+     1. Create a venv just for that notebook
+     2. Verify the notebook executes without error (and that it installs its own dependencies!)
+     3. Clean up venv dir
+
+    A scratch directory dev_tools/notebook_envs will be created containing tvenv as well as
+    stdout and stderr logs for each notebook. Each of these files and directories will be
+    named according to the "notebook_id", which is `notebook_fn.replace('/', '-')`.
+
+    The executed notebook will be rendered to html alongside its original .ipynb file for
+    spot-checking.
+
+    Args:
+        notebook_fn: The filename of the notebook relative to the repo root.
+    """
+    notebook_id = notebook_fn.replace('/', '-')
+    start = time.perf_counter()
+    with open(f'./notebook_envs/{notebook_id}.stdout', 'w') as stdout, \
+            open(f'./notebook_envs/{notebook_id}.stderr', 'w') as stderr:
+        try:
+            _check_notebook(notebook_fn, notebook_id, stdout, stderr)
+        except CalledProcessError:
+            print('ERROR!', notebook_id)
+    end = time.perf_counter()
+    print(f'{notebook_id} {end - start:.1f}s')
+
+
+NOTEBOOKS = [
+    'docs/otoc/otoc_example.ipynb',
+    'docs/guide/data_analysis.ipynb',
+    'docs/guide/data_collection.ipynb',
+    'docs/qaoa/example_problems.ipynb',
+    'docs/qaoa/precomputed_analysis.ipynb',
+    'docs/qaoa/hardware_grid_circuits.ipynb',
+    'docs/qaoa/optimization_analysis.ipynb',
+    'docs/qaoa/tasks.ipynb',
+    'docs/qaoa/landscape_analysis.ipynb',
+    'docs/qaoa/routing_with_tket.ipynb',
+    'docs/quantum_chess/concepts.ipynb',
+    # 'docs/quantum_chess/quantum_chess_rest_api.ipynb', # runs a server, never finishes.
+    # 'docs/quantum_chess/quantum_chess_client.ipynb',   # uses the server, requires modification.
+    'docs/hfvqe/molecular_data.ipynb',
+    'docs/hfvqe/quickstart.ipynb',
+    'docs/fermi_hubbard/publication_results.ipynb',
+    'docs/fermi_hubbard/experiment_example.ipynb',
+]
+
+
+def main():
+    os.chdir(os.path.dirname(__file__))
+    os.makedirs('./notebook_envs', exist_ok=True)
+    with Pool(4) as pool:
+        results = pool.map(check_notebook, NOTEBOOKS)
+    print(results)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/qaoa/optimization_analysis.ipynb
+++ b/docs/qaoa/optimization_analysis.ipynb
@@ -64,7 +64,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "314b4703b85b"
+   },
    "source": [
     "## Setup\n",
     "\n",
@@ -74,7 +76,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "id": "ca9285a3a162"
+   },
    "outputs": [],
    "source": [
     "try:\n",

--- a/docs/qaoa/optimization_analysis.ipynb
+++ b/docs/qaoa/optimization_analysis.ipynb
@@ -64,6 +64,27 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install the ReCirq package:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import recirq\n",
+    "except ImportError:\n",
+    "    !pip install -q git+https://github.com/quantumlib/ReCirq sympy~=1.6"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "ab6ae3f3c490"
    },


### PR DESCRIPTION
Add a script to run full notebook checks locally.

## Don't we already have notebook checks?

Short: not really. Most of the notebooks get "tested" during doc building, rendering, and pushing which happens outside of GitHub. For some reason I don't get the emails when these fail but usually @MichaelBroughton will ping me.

A small portion of notebooks are too long-running, so their outputs are saved and the notebooks are not executed during doc building and are untested.

Some notebooks were written with one data generation notebook and one data consumption (analysis) notebook. The original doc build system supported this. The current doc build system requires independent notebooks. Some domains have been ported to a regime where a fetch function will download the example dataset from figshare for the analysis notebooks. This hasn't been done for all domains, so there are output-saved notebooks that are not tested.

The original notebook tests for ReCirq were done as part of the CI but coupled to the sphinx build system, which was removed cc #198.

## How good of a test is this?

Short: good, but expensive. Since we want to support the flow where a user has launched an individual notebook into a **vanilla** colab and have everything work, the checks in this script are very expensive and realistic. It will create a new venv virtual environment for each. As such, running the full thing is expensive.

## Is this part of the CI?

Short: no. This is an expensive but fully automated and complete end-to-end tests of the notebooks to save me the trouble of going through and manually checking colabs when e.g. I do a Cirq bump. The script in its current form is designed for manual execution.

To have automated checks as part of the CI, we'd likely have to do something fancy like Cirq where we only do isolated env tests in particular circumstances and/or only check changed notebooks. 

But this is a good starting point for a CI notebook check.

