### PR TITLE
loschmidt.tilted_square_lattice gen+run

### DIFF
--- a/recirq/algorithmic_benchmark_library.py
+++ b/recirq/algorithmic_benchmark_library.py
@@ -1,7 +1,7 @@
 import dataclasses
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Type, Callable, List, Tuple, Any
+from typing import Type, Callable, List, Tuple, Any, Optional
 
 import pandas as pd
 
@@ -48,6 +48,7 @@ class AlgorithmicBenchmark:
     spec_class: Type['ExecutableSpec']
     executable_generator_func: Callable[[Any], 'QuantumExecutableGroup']
     configs: List['BenchmarkConfig']
+    description: Optional[str] = None
 
     def as_strings(self):
         """Get values of this class as strings suitable for printing."""
@@ -73,6 +74,7 @@ class BenchmarkConfig:
     full_name: str
     gen_script: str
     run_scripts: List[str]
+    description: Optional[str] = None
 
 
 BENCHMARKS = [
@@ -80,12 +82,28 @@ BENCHMARKS = [
         domain='recirq.otoc',
         name='loschmidt.tilted_square_lattice',
         executable_family='recirq.otoc.loschmidt.tilted_square_lattice',
+        description='\n'.join([
+            "An OTOC-style Loschmidt Echo on a tilted square lattice topology.",
+            "",
+            "This benchmark involves running a random unitary U forwards and backwards to",
+            "measure the fraction of times one ends up back in the starting state.",
+            "",
+            "Please browse the docstring for `TiltedSquareLatticeLoschmidtSpec` for details",
+            "on available parameters."
+        ]),
         spec_class=TiltedSquareLatticeLoschmidtSpec,
         executable_generator_func=get_all_tilted_square_lattice_executables,
         configs=[
             BenchmarkConfig(
                 short_name='small-v1',
                 full_name='loschmidt.tilted_square_lattice.small-v1',
+                description='\n'.join([
+                    "A 'small' configuration for quick verification of Loschmidt echos",
+                    "",
+                    "This configuration uses small grid topologies (making it suitable for",
+                    "running on simulators) and a small number of random instances making it",
+                    "suitable for getting a quick reading on processor performance in ~minutes."
+                ]),
                 gen_script='gen-small-v1.py',
                 run_scripts=['run-simulator.py']
             )

--- a/recirq/algorithmic_benchmark_library.py
+++ b/recirq/algorithmic_benchmark_library.py
@@ -1,7 +1,7 @@
 import dataclasses
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Type, Callable, List, Tuple, Any, Optional
+from typing import Type, Callable, List, Tuple, Any, Optional, Dict
 
 import pandas as pd
 
@@ -50,7 +50,7 @@ class AlgorithmicBenchmark:
     configs: List['BenchmarkConfig']
     description: Optional[str] = None
 
-    def as_strings(self):
+    def as_strings(self) -> Dict[str, str]:
         """Get values of this class as strings suitable for printing."""
         ret = {k: str(v) for k, v in dataclasses.asdict(self).items()}
         ret['spec_class'] = self.spec_class.__name__

--- a/recirq/algorithmic_benchmark_library.py
+++ b/recirq/algorithmic_benchmark_library.py
@@ -83,6 +83,12 @@ BENCHMARKS = [
         spec_class=TiltedSquareLatticeLoschmidtSpec,
         executable_generator_func=get_all_tilted_square_lattice_executables,
         configs=[
+            BenchmarkConfig(
+                short_name='small-v1',
+                full_name='loschmidt.tilted_square_lattice.small-v1',
+                gen_script='gen-small-v1.py',
+                run_scripts=['run-simulator.py']
+            )
         ]
     ),
 ]

--- a/recirq/cirqflow/__init__.py
+++ b/recirq/cirqflow/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/recirq/cirqflow/run_utils.py
+++ b/recirq/cirqflow/run_utils.py
@@ -24,6 +24,9 @@ def get_unique_run_id(fmt: str = 'run-{i}', base_data_dir: str = '.') -> str:
         fmt: A format string containing {i} and optionally {date} to template trial run_ids.
         base_data_dir: The directory to check for the existence of files or directories.
     """
+    if '{i}' not in fmt:
+        raise ValueError("run_id format string must contain an '{i}' placeholder.")
+
     i = 1
     while True:
         run_id = fmt.format(i=i, date=datetime.date.today().isoformat())

--- a/recirq/cirqflow/run_utils.py
+++ b/recirq/cirqflow/run_utils.py
@@ -1,0 +1,20 @@
+import datetime
+import os
+
+
+def get_unique_run_id(fmt: str = 'run-{i}', base_data_dir: str = '.') -> str:
+    """Find an unused run_id by checking for existing paths and incrementing `i` in `fmt` until
+    an unused path name is found.
+
+    Args:
+        fmt: A format string containing {i} and optionally {date} to template trial run_ids.
+        base_data_dir: The directory to check for the existence of files or directories.
+    """
+    i = 1
+    while True:
+        run_id = fmt.format(i=i, date=datetime.date.today().isoformat())
+        if not os.path.exists(f'{base_data_dir}/{run_id}'):
+            break  # found an unused run_id
+        i += 1
+
+    return run_id

--- a/recirq/cirqflow/run_utils.py
+++ b/recirq/cirqflow/run_utils.py
@@ -1,3 +1,17 @@
+# Copyright 2022 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import datetime
 import os
 

--- a/recirq/cirqflow/run_utils_test.py
+++ b/recirq/cirqflow/run_utils_test.py
@@ -1,0 +1,38 @@
+# Copyright 2022 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import os
+
+import pytest
+
+from recirq.cirqflow.run_utils import get_unique_run_id
+
+
+def test_get_unique_run_id(tmpdir):
+    run_id = get_unique_run_id(base_data_dir=f'{tmpdir}')
+    assert run_id == 'run-1'
+
+    run_id = get_unique_run_id('myrun-{i}', base_data_dir=f'{tmpdir}')
+    assert run_id == 'myrun-1'
+    os.makedirs(f'{tmpdir}/{run_id}')
+
+    run_id = get_unique_run_id('myrun-{i}', base_data_dir=f'{tmpdir}')
+    assert run_id == 'myrun-2'
+
+    with pytest.raises(ValueError):
+        get_unique_run_id('myrun', base_data_dir=f'{tmpdir}')
+
+    run_id = get_unique_run_id('myrun-{date}-{i}', base_data_dir=f'{tmpdir}')
+    assert datetime.date.today().isoformat() in run_id

--- a/recirq/otoc/loschmidt/tilted_square_lattice/.gitignore
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/.gitignore
@@ -1,0 +1,1 @@
+loschmidt.tilted_square_lattice.small-v1.json.gz

--- a/recirq/otoc/loschmidt/tilted_square_lattice/end-to-end-test.sh
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/end-to-end-test.sh
@@ -1,3 +1,22 @@
+# Copyright 2022 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# end-to-end-test.sh
+#
+# This is a *very basic* test that the scripts in this directory can execute
+# successfully.
+
 python gen-small-v1.py
 rm -rf simulated-1/
 python run-simulator.py

--- a/recirq/otoc/loschmidt/tilted_square_lattice/end-to-end-test.sh
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/end-to-end-test.sh
@@ -1,0 +1,3 @@
+python gen-small-v1.py
+rm -rf simulated-1/
+python run-simulator.py

--- a/recirq/otoc/loschmidt/tilted_square_lattice/gen-small-v1.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/gen-small-v1.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+import cirq
+from recirq.otoc.loschmidt.tilted_square_lattice import \
+    get_all_tilted_square_lattice_executables
+
+FN = 'loschmidt.tilted_square_lattice.small-v1.json.gz'
+
+
+def main():
+    exes = get_all_tilted_square_lattice_executables(
+        min_side_length=2, max_side_length=3, side_length_step=1,
+        n_instances=3,
+        macrocycle_depths=np.arange(0, 4 + 1, 1))
+    print(len(exes), 'executables')
+
+    cirq.to_json_gzip(exes, FN)
+    print(f'Wrote {FN}')
+
+
+if __name__ == '__main__':
+    main()

--- a/recirq/otoc/loschmidt/tilted_square_lattice/gen-small-v1.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/gen-small-v1.py
@@ -1,10 +1,41 @@
+# Copyright 2022 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate the QuantumExecutableGroup for the small-v1 configuration of the
+loschmidt.tilted_square_lattice benchmark.
+
+
+The `small-v1` configuration is A 'small' configuration for quick verification
+of Loschmidt echos.
+
+This configuration uses small grid topologies (making it suitable for
+running on simulators) and a small number of random instances making it
+suitable for getting a quick reading on processor performance in ~minutes.
+
+To run:
+
+    python gen-small-v1.py
+
+"""
+
 import numpy as np
 
 import cirq
 from recirq.otoc.loschmidt.tilted_square_lattice import \
     get_all_tilted_square_lattice_executables
 
-FN = 'loschmidt.tilted_square_lattice.small-v1.json.gz'
+EXES_FILENAME = 'loschmidt.tilted_square_lattice.small-v1.json.gz'
 
 
 def main():
@@ -14,8 +45,8 @@ def main():
         macrocycle_depths=np.arange(0, 4 + 1, 1))
     print(len(exes), 'executables')
 
-    cirq.to_json_gzip(exes, FN)
-    print(f'Wrote {FN}')
+    cirq.to_json_gzip(exes, EXES_FILENAME)
+    print(f'Wrote {EXES_FILENAME}')
 
 
 if __name__ == '__main__':

--- a/recirq/otoc/loschmidt/tilted_square_lattice/run-simulator.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/run-simulator.py
@@ -1,3 +1,23 @@
+# Copyright 2022 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A script for executing the loschmidt.tilted_square_lattice benchmark on a simulator.
+
+Practitioners should copy this script to provide their own parameters for
+QuantumRuntimeConfiguration.
+"""
+
 import cirq
 from cirq_google.workflow import QuantumRuntimeConfiguration, \
     SimulatedProcessorWithLocalDeviceRecord, execute
@@ -6,11 +26,11 @@ from recirq.otoc.loschmidt.tilted_square_lattice import TiltedSquareLatticeLosch
 
 assert TiltedSquareLatticeLoschmidtSpec, 'register deserializer'
 
-FN = 'loschmidt.tilted_square_lattice.small-v1.json.gz'
+EXES_FILENAME = 'loschmidt.tilted_square_lattice.small-v1.json.gz'
 
 
 def main():
-    exegroup = cirq.read_json_gzip(FN)
+    exegroup = cirq.read_json_gzip(EXES_FILENAME)
     rt_config = QuantumRuntimeConfiguration(
         processor_record=SimulatedProcessorWithLocalDeviceRecord('rainbow', noise_strength=0.005),
         run_id=get_unique_run_id('simulated-{i}'),

--- a/recirq/otoc/loschmidt/tilted_square_lattice/run-simulator.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/run-simulator.py
@@ -1,0 +1,24 @@
+import cirq
+from cirq_google.workflow import QuantumRuntimeConfiguration, execute
+from recirq.cirqflow.quantum_backend import SimulatedEngineProcessorWithLocalDevice
+from recirq.cirqflow.run_utils import get_unique_run_id
+from recirq.otoc.loschmidt.tilted_square_lattice import TiltedSquareLatticeLoschmidtSpec
+
+assert TiltedSquareLatticeLoschmidtSpec, 'register deserializer'
+
+FN = 'loschmidt.tilted_square_lattice.small-v1.json.gz'
+
+
+def main():
+    exegroup = cirq.read_json_gzip(FN)
+    rt_config = QuantumRuntimeConfiguration(
+        processor=SimulatedEngineProcessorWithLocalDevice('rainbow', noise_strength=0.005),
+        run_id=get_unique_run_id('simulated-{i}'),
+        random_seed=52,
+    )
+    raw_results = execute(rt_config, exegroup)
+    print("Finished run_id", raw_results.shared_runtime_info.run_id)
+
+
+if __name__ == '__main__':
+    main()

--- a/recirq/otoc/loschmidt/tilted_square_lattice/run-simulator.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/run-simulator.py
@@ -1,6 +1,6 @@
 import cirq
-from cirq_google.workflow import QuantumRuntimeConfiguration, execute
-from recirq.cirqflow.quantum_backend import SimulatedEngineProcessorWithLocalDevice
+from cirq_google.workflow import QuantumRuntimeConfiguration, \
+    SimulatedProcessorWithLocalDeviceRecord, execute
 from recirq.cirqflow.run_utils import get_unique_run_id
 from recirq.otoc.loschmidt.tilted_square_lattice import TiltedSquareLatticeLoschmidtSpec
 
@@ -12,7 +12,7 @@ FN = 'loschmidt.tilted_square_lattice.small-v1.json.gz'
 def main():
     exegroup = cirq.read_json_gzip(FN)
     rt_config = QuantumRuntimeConfiguration(
-        processor=SimulatedEngineProcessorWithLocalDevice('rainbow', noise_strength=0.005),
+        processor_record=SimulatedProcessorWithLocalDeviceRecord('rainbow', noise_strength=0.005),
         run_id=get_unique_run_id('simulated-{i}'),
         random_seed=52,
     )


### PR DESCRIPTION
Following #236 , add scripts for generating a QuantumExecutableGroup and a script for running on a simulated EngineProcessor. 

This PR includes a very simple placeholder bash script for doing an "end-to-end" test that will be replaced with a more comprehensive solution when we have all the end-to-end parts committed. 

This PR does not include the data analysis steps, which will follow.

This requires https://github.com/quantumlib/Cirq/pull/4842