### PR TITLE
Pytest skip breakage

### DIFF
--- a/recirq/qaoa/gates_and_compilation_test.py
+++ b/recirq/qaoa/gates_and_compilation_test.py
@@ -278,7 +278,7 @@ def test_zzswap_as_syc():
     cirq.testing.assert_allclose_up_to_global_phase(u1, u2, atol=1e-8)
 
 
-@pytest.mark.skip(msg="KAK instability")
+@pytest.mark.skip("KAK instability")
 def test_zzswap_as_syc_2():
     q1, q2 = cirq.LineQubit.range(2)
     zzs = ZZSwap(zz_exponent=0.123)

--- a/recirq/qaoa/gates_and_compilation_test.py
+++ b/recirq/qaoa/gates_and_compilation_test.py
@@ -301,7 +301,7 @@ def test_zz_as_syc():
     cirq.testing.assert_allclose_up_to_global_phase(u1, u2, atol=1e-8)
 
 
-@pytest.mark.skip(msg="KAK instability")
+@pytest.mark.skip("KAK instability")
 def test_zz_as_syc_2():
     q1, q2 = cirq.LineQubit.range(2)
     zz = cirq.ZZPowGate(exponent=0.123)


### PR DESCRIPTION
Somehow this changed? Seeing errors in #259 