### PR TITLE
Fix f-strings in toric code

### DIFF
--- a/recirq/toric_code/toric_code_plotter.py
+++ b/recirq/toric_code/toric_code_plotter.py
@@ -257,7 +257,7 @@ class ToricCodePlotter:
                 figsize = (2.0, 0.1)
             else:
                 raise ValueError(
-                    f'Invalid {orientation=}, expected "vertical" or "horizontal"'
+                    f'Invalid orientation={orientation}, expected "vertical" or "horizontal"'
                 )
             _fig, ax = plt.subplots(figsize=figsize)
 

--- a/recirq/toric_code/toric_code_rectangle.py
+++ b/recirq/toric_code/toric_code_rectangle.py
@@ -116,7 +116,7 @@ class ToricCodeRectangle:
             cols: Number of columns of X plaquettes
         """
         if np.any(np.abs(row_vector) != np.array([1, 1])):
-            raise ValueError(f"Illegal {row_vector=}: must be (±1, ±1)")
+            raise ValueError(f"Illegal row_vector={row_vector}: must be (±1, ±1)")
 
         if rows < 1 or cols < 1:
             raise ValueError(f"rows ({rows}) and cols ({cols}) must both be at least 1")


### PR DESCRIPTION
- f'{blah=}' is not supported by the python runtime in
colab hosted runtimes.