### PR TITLE
Support multiple twoq gates in loschmidt.tilted_square_lattice

### DIFF
--- a/recirq/algorithmic_benchmark_library.py
+++ b/recirq/algorithmic_benchmark_library.py
@@ -106,6 +106,20 @@ BENCHMARKS = [
                 ]),
                 gen_script='gen-small-v1.py',
                 run_scripts=['run-simulator.py']
+            ),
+            BenchmarkConfig(
+                short_name='small-cz-v1',
+                full_name='loschmidt.tilted_square_lattice.small-cz-v1',
+                description='\n'.join([
+                    "A 'small' configuration for quick verification of Loschmidt echos using the ",
+                    "CZ gate",
+                    "",
+                    "This configuration uses small grid topologies (making it suitable for",
+                    "running on simulators) and a small number of random instances making it",
+                    "suitable for getting a quick reading on processor performance in ~minutes."
+                ]),
+                gen_script='gen-small-cz-v1.py',
+                run_scripts=['run-simulator-cz.py']
             )
         ]
     ),

--- a/recirq/otoc/loschmidt/tilted_square_lattice/.gitignore
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/.gitignore
@@ -1,1 +1,2 @@
 loschmidt.tilted_square_lattice.small-v1.json.gz
+loschmidt.tilted_square_lattice.small-cz-v1.json.gz

--- a/recirq/otoc/loschmidt/tilted_square_lattice/end-to-end-test.sh
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/end-to-end-test.sh
@@ -18,5 +18,6 @@
 # successfully.
 
 python gen-small-v1.py
+python gen-small-cz-v1.py
 rm -rf simulated-1/
 python run-simulator.py

--- a/recirq/otoc/loschmidt/tilted_square_lattice/gen-small-cz-v1.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/gen-small-cz-v1.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Generate the QuantumExecutableGroup for the small-v1 configuration of the
+"""Generate the QuantumExecutableGroup for the small-cz-v1 configuration of the
 loschmidt.tilted_square_lattice benchmark.
 
-The `small-v1` configuration is A 'small' configuration for quick verification
-of Loschmidt echos.
+The `small-cz-v1` configuration is A 'small' configuration for quick verification
+of Loschmidt echos using the CZ gate.
 
 This configuration uses small grid topologies (making it suitable for
 running on simulators) and a small number of random instances making it
@@ -24,7 +24,7 @@ suitable for getting a quick reading on processor performance in ~minutes.
 
 To run:
 
-    python gen-small-v1.py
+    python gen-small-cz-v1.py
 
 """
 
@@ -34,14 +34,16 @@ import cirq
 from recirq.otoc.loschmidt.tilted_square_lattice import \
     get_all_tilted_square_lattice_executables
 
-EXES_FILENAME = 'loschmidt.tilted_square_lattice.small-v1.json.gz'
+EXES_FILENAME = 'loschmidt.tilted_square_lattice.small-cz-v1.json.gz'
 
 
 def main():
     exes = get_all_tilted_square_lattice_executables(
         min_side_length=2, max_side_length=3, side_length_step=1,
         n_instances=3,
-        macrocycle_depths=np.arange(0, 4 + 1, 1))
+        macrocycle_depths=np.arange(0, 4 + 1, 1),
+        twoq_gate_name='cz',
+    )
     print(len(exes), 'executables')
 
     cirq.to_json_gzip(exes, EXES_FILENAME)

--- a/recirq/otoc/loschmidt/tilted_square_lattice/run-simulator.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/run-simulator.py
@@ -19,8 +19,10 @@ QuantumRuntimeConfiguration.
 """
 
 import cirq
-from cirq_google.workflow import QuantumRuntimeConfiguration, \
-    SimulatedProcessorWithLocalDeviceRecord, execute
+from cirq_google.workflow import (
+    QuantumRuntimeConfiguration, SimulatedProcessorWithLocalDeviceRecord, RandomDevicePlacer,
+    execute
+)
 from recirq.cirqflow.run_utils import get_unique_run_id
 from recirq.otoc.loschmidt.tilted_square_lattice import TiltedSquareLatticeLoschmidtSpec
 
@@ -33,6 +35,7 @@ def main():
     exegroup = cirq.read_json_gzip(EXES_FILENAME)
     rt_config = QuantumRuntimeConfiguration(
         processor_record=SimulatedProcessorWithLocalDeviceRecord('rainbow', noise_strength=0.005),
+        qubit_placer=RandomDevicePlacer(),
         run_id=get_unique_run_id('simulated-{i}'),
         random_seed=52,
     )

--- a/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice.py
@@ -92,6 +92,8 @@ class TiltedSquareLatticeLoschmidtSpec(ExecutableSpec):
         instance_i: An arbitary index into the random instantiation
         n_repetitions: The number of repetitions to sample to measure the return probability.
         executable_family: The globally unique string identifier for this benchmark.
+        twoq_gate_name: The name of the two-qubit entangling gate used in the random unitary. See
+            `tilted_square_lattice_spec_to_exe` for currently supported values.
     """
 
     topology: TiltedSquareLattice
@@ -126,6 +128,7 @@ def get_all_tilted_square_lattice_specs(
         min_side_length, max_side_length, side_length_step: generate a range of
             TiltedSquareLattice topologies with widths and heights in this range.
         macrocycle_depths: The collection of macrocycle depths to use per setting.
+        twoq_gate_name: The name of the two-qubit entangling gate used in the random unitary.
     """
 
     if macrocycle_depths is None:
@@ -155,6 +158,7 @@ def tilted_square_lattice_spec_to_exe(
     """Create a full `QuantumExecutable` from a given `TiltedSquareLatticeLoschmidtSpec`
 
     This "fleshes out" the specification into a complete executable with a random circuit.
+    The spec's `twoq_gate_name` must be one of "sqrt_iswap" or "cz".
 
     Args:
         spec: The spec
@@ -202,6 +206,7 @@ def get_all_tilted_square_lattice_executables(
             TiltedSquareLattice topologies with widths and heights in this range.
         seed: The random seed to make this deterministic.
         macrocycle_depths: The collection of macrocycle depths to use per setting.
+        twoq_gate_name: The name of the two-qubit entangling gate used in the random unitary.
     """
     rs = np.random.RandomState(seed)
     specs = get_all_tilted_square_lattice_specs(

--- a/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice.py
@@ -152,6 +152,20 @@ def get_all_tilted_square_lattice_specs(
 def tilted_square_lattice_spec_to_exe(
         spec: TiltedSquareLatticeLoschmidtSpec, *, rs: np.random.RandomState
 ) -> QuantumExecutable:
+    """Create a full `QuantumExecutable` from a given `TiltedSquareLatticeLoschmidtSpec`
+
+    This "fleshes out" the specification into a complete executable with a random circuit.
+
+    Args:
+        spec: The spec
+        rs: A random state. The ExecutableSpec only specifies an `instance_i` and this function
+            is responsible for generating a pseudo-random circuit for each `instance_i`. Therefore,
+            some care should be taken when using this function to share a `RandomState` among
+            all calls to this function.
+
+    Returns:
+        a QuantumExecutable corresponding to the input specification.
+    """
     twoq_gates = {
         'sqrt_iswap': cirq.SQRT_ISWAP,
         'cz': cirq.CZ,

--- a/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice_test.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/tilted_square_lattice_test.py
@@ -15,11 +15,14 @@
 import numpy as np
 
 import cirq
+import cirq_google as cg
 # Need this exact import for monkeypatching to work (below)
 import recirq.otoc.loschmidt.tilted_square_lattice.tilted_square_lattice
-from recirq.otoc.loschmidt.tilted_square_lattice import \
-    create_tilted_square_lattice_loschmidt_echo_circuit, TiltedSquareLatticeLoschmidtSpec, \
-    get_all_tilted_square_lattice_executables
+from recirq.otoc.loschmidt.tilted_square_lattice import (
+    create_tilted_square_lattice_loschmidt_echo_circuit, TiltedSquareLatticeLoschmidtSpec,
+    get_all_tilted_square_lattice_executables, get_all_tilted_square_lattice_specs,
+    tilted_square_lattice_spec_to_exe,
+)
 
 
 def test_create_tilted_square_lattice_loschmidt_echo_circuit():
@@ -95,3 +98,21 @@ def test_get_all_tilted_square_lattice_executables():
     assert sorted({exe.spec.macrocycle_depth for exe in exes}) == [2, 4]
     assert sorted({exe.spec.topology.width for exe in exes}) == [2, 3]
     assert sorted({exe.spec.topology.height for exe in exes}) == [2, 3]
+
+
+def test_get_all_tilted_square_lattice_specs():
+    specs = get_all_tilted_square_lattice_specs()
+    assert len(specs) == 400
+    for spec in specs:
+        assert spec.twoq_gate_name == 'sqrt_iswap'
+
+
+def test_tilted_square_lattice_spec_to_exe():
+    rs = np.random.RandomState()
+    exe = tilted_square_lattice_spec_to_exe(TiltedSquareLatticeLoschmidtSpec(
+        topology=cirq.TiltedSquareLattice(2, 2),
+        macrocycle_depth=1, instance_i=123, n_repetitions=1_000
+    ), rs=rs)
+    assert isinstance(exe, cg.QuantumExecutable)
+    assert exe.measurement.n_repetitions == 1_000
+    assert len(exe.circuit) == 18 + 1


### PR DESCRIPTION
The only constant is change, and as our hardware evolves so to must the benchmark library.

This PR demonstrates how we can introduce a new `BenchmarkConfig` for a given `AlgorithmicBenchmark`. 

Because the loschmidt echo benchmark is fairly low-level, the two qubit gate is part of the executable. Running random circuits with sqrt_iswap is a different task than running random circuits with cz. This PR plumbs through a new `twoq_gate_name` spec parameter. 

I've also taken the liberty of refactoring the generation of a collection of `TiltedSquareLatticeLoschmidtSpec` objects from their transformation into `QuantumExecutable`s. Some care has to be taken to share the `RandomState` for correct deterministic-randomness in crafting the executables.