### PR TITLE
Fix import of now-private functions in QAOA

### DIFF
--- a/recirq/qaoa/gates_and_compilation.py
+++ b/recirq/qaoa/gates_and_compilation.py
@@ -12,8 +12,8 @@ from recirq.qaoa.problems import _validate_problem_graph
 try:
     from cirq_google.optimizers.convert_to_sycamore_gates import swap_rzz, rzz
 except ImportError:
-    from cirq_google.optimizers.convert_to_sycamore_gates import _swap_rzz as swap_rzz
-    from cirq_google.optimizers.convert_to_sycamore_gates import _rzz as rzz
+    from cirq-google.cirq_google.transformers.analytical_decompositions.two_qubit_to_sycamore import _swap_rzz as swap_rzz
+    from cirq-google.cirq_google.transformers.analytical_decompositions.two_qubit_to_sycamore import _rzz as rzz
 
 try:
     from cirq.interop.quirk import QuirkQubitPermutationGate

--- a/recirq/qaoa/gates_and_compilation.py
+++ b/recirq/qaoa/gates_and_compilation.py
@@ -12,8 +12,8 @@ from recirq.qaoa.problems import _validate_problem_graph
 try:
     from cirq_google.optimizers.convert_to_sycamore_gates import swap_rzz, rzz
 except ImportError:
-    from cirq-google.cirq_google.transformers.analytical_decompositions.two_qubit_to_sycamore import _swap_rzz as swap_rzz
-    from cirq-google.cirq_google.transformers.analytical_decompositions.two_qubit_to_sycamore import _rzz as rzz
+    from cirq_google.cirq_google.transformers.analytical_decompositions.two_qubit_to_sycamore import _swap_rzz as swap_rzz
+    from cirq_google.cirq_google.transformers.analytical_decompositions.two_qubit_to_sycamore import _rzz as rzz
 
 try:
     from cirq.interop.quirk import QuirkQubitPermutationGate

--- a/recirq/qaoa/gates_and_compilation.py
+++ b/recirq/qaoa/gates_and_compilation.py
@@ -12,8 +12,8 @@ from recirq.qaoa.problems import _validate_problem_graph
 try:
     from cirq_google.optimizers.convert_to_sycamore_gates import swap_rzz, rzz
 except ImportError:
-    from cirq_google.cirq_google.transformers.analytical_decompositions.two_qubit_to_sycamore import _swap_rzz as swap_rzz
-    from cirq_google.cirq_google.transformers.analytical_decompositions.two_qubit_to_sycamore import _rzz as rzz
+    from cirq_google.transformers.analytical_decompositions.two_qubit_to_sycamore import _swap_rzz as swap_rzz
+    from cirq_google.transformers.analytical_decompositions.two_qubit_to_sycamore import _rzz as rzz
 
 try:
     from cirq.interop.quirk import QuirkQubitPermutationGate

--- a/recirq/qaoa/gates_and_compilation.py
+++ b/recirq/qaoa/gates_and_compilation.py
@@ -5,8 +5,15 @@ import networkx as nx
 import numpy as np
 
 import cirq
-from cirq_google.optimizers.convert_to_sycamore_gates import swap_rzz, rzz
 from recirq.qaoa.problems import _validate_problem_graph
+
+
+#TODO(mpharrigan): We should change this to use non-private functions
+try:
+    from cirq_google.optimizers.convert_to_sycamore_gates import swap_rzz, rzz
+except ImportError:
+    from cirq_google.optimizers.convert_to_sycamore_gates import _swap_rzz as swap_rzz
+    from cirq_google.optimizers.convert_to_sycamore_gates import _rzz as rzz
 
 try:
     from cirq.interop.quirk import QuirkQubitPermutationGate

--- a/recirq/quantum_chess/controlled_iswap_test.py
+++ b/recirq/quantum_chess/controlled_iswap_test.py
@@ -46,10 +46,6 @@ def test_controlled_inv_iswap():
 def test_controlled_sqrt_iswap():
     qubits = cirq.LineQubit.range(3)
     result = controlled_iswap.controlled_sqrt_iswap(qubits[0], qubits[1], qubits[2])
-    import numpy
-
-    numpy.set_printoptions(linewidth=200, precision=3)
-    print(numpy.around(cirq.unitary(result), decimals=2))
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.unitary(result),
         cirq.unitary(
@@ -57,17 +53,13 @@ def test_controlled_sqrt_iswap():
                 (cirq.ISWAP(qubits[0], qubits[1]) ** 0.5).controlled_by(qubits[2])
             )
         ),
-        atol=1e-8,
+        atol=1e-6,
     )
 
 
 def test_controlled_inv_sqrt_iswap():
     qubits = cirq.LineQubit.range(3)
     result = controlled_iswap.controlled_inv_sqrt_iswap(qubits[0], qubits[1], qubits[2])
-    import numpy
-
-    numpy.set_printoptions(linewidth=200, precision=3)
-    print(numpy.around(cirq.unitary(result), decimals=2))
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.unitary(result),
         cirq.unitary(
@@ -75,5 +67,5 @@ def test_controlled_inv_sqrt_iswap():
                 (cirq.ISWAP(qubits[0], qubits[1]) ** -0.5).controlled_by(qubits[2])
             )
         ),
-        atol=1e-8,
+        atol=1e-6,
     )


### PR DESCRIPTION
- swap_rzz and rzz are now private functions.
- Update import statements as a workaround until a more
permanent fix can be done.