### PR TITLE
[loschmidt] plots.ipynb

### DIFF
--- a/recirq/otoc/loschmidt/tilted_square_lattice/analysis-walkthrough.ipynb
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/analysis-walkthrough.ipynb
@@ -116,12 +116,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agg_df1, gb_cols1 = analysis.groupby_all_except(\n",
+    "means_df, means_gb_cols = analysis.groupby_all_except(\n",
     "    df.drop(['n_qubits', 'q_area'], axis=1), \n",
     "    y_cols=('instance_i', 'success_probability'), \n",
     "    agg_func={'success_probability': ['mean', 'std']}\n",
     ")\n",
-    "agg_df1"
+    "means_df"
    ]
   },
   {
@@ -137,12 +137,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agg_df2, gb_cols2 = analysis.groupby_all_except(\n",
-    "    agg_df1, \n",
+    "vs_depth_df, vs_depth_gb_cols = analysis.groupby_all_except(\n",
+    "    means_df, \n",
     "    y_cols=('macrocycle_depth', 'success_probability_mean', 'success_probability_std'),\n",
     "    agg_func=list\n",
     ")\n",
-    "agg_df2"
+    "vs_depth_df"
    ]
   },
   {
@@ -151,20 +151,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for i, row in agg_df2.iterrows():\n",
-    "    label = ' '.join(f'{cc}={row[cc]}' for cc in gb_cols2)\n",
+    "for i, row in vs_depth_df.iterrows():\n",
     "    plt.errorbar(\n",
     "        x=row['macrocycle_depth'],\n",
     "        y=row['success_probability_mean'],\n",
     "        yerr=row['success_probability_std'],\n",
-    "        label=', '.join(f'{row[col]}' for col in gb_cols2),\n",
+    "        label=', '.join(f'{row[col]}' for col in vs_depth_gb_cols),\n",
     "        capsize=5, ls='', marker='o',\n",
     "    )\n",
     "    \n",
     "plt.xlabel('Macrocycle Depth')\n",
     "plt.ylabel('Success Probability')\n",
-    "plt.legend(title=','.join(gb_cols2), loc='best')\n",
+    "plt.legend(title=','.join(vs_depth_gb_cols), loc='best')\n",
     "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The two aggregation steps (1) and (2) are encapsulated in `analysis.agg_vs_macrocycle_depth`."
    ]
   },
   {
@@ -224,7 +230,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(gb_cols2)\n",
+    "print(vs_depth_gb_cols)\n",
     "print(gb_cols3)"
    ]
   },
@@ -234,7 +240,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "total_df = pd.merge(agg_df2, fit_df, on=gb_cols2)\n",
+    "total_df = pd.merge(vs_depth_df, fit_df, on=vs_depth_gb_cols)\n",
     "total_df"
    ]
   },
@@ -253,7 +259,7 @@
     "        yerr=row['success_probability_std'],\n",
     "        marker='o', capsize=5, ls='',\n",
     "        color=colors(i),\n",
-    "        label=f'{row[\"width\"]}x{row[\"height\"]} ({row[\"n_qubits\"]}q) {row[\"processor_id\"]}; f={row[\"f\"]:.3f}'\n",
+    "        label=f'{row[\"width\"]}x{row[\"height\"]} ({row[\"n_qubits\"]}q) {row[\"processor_str\"]}; f={row[\"f\"]:.3f}'\n",
     "    )\n",
     "    \n",
     "    xx = np.linspace(np.min(row['macrocycle_depth']), np.max(row['macrocycle_depth']))\n",
@@ -306,7 +312,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once again, we'll merge (join) the raw data with the fits data. This seems like overkill since everthing has been grouped into one DataFrame row, but this code will run without modification when comparing multiple runs or multiple processors."
+    "Once again, we'll merge (join) the raw data with the fits data. We use `analysis.agg_vs_q_area` to aggregate the raw data. It works very similar to the `vs_depth` aggregation explained above.\n",
+    "\n",
+    "Using dataframes at this level of aggregation seems like overkill since everthing has been grouped into one DataFrame row, but this code will run without modification when comparing multiple runs or multiple processors."
    ]
   },
   {
@@ -315,7 +323,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "total_df2 = pd.merge(agg_df4, fit_df2, on=gb_cols4)\n",
+    "vs_q_area_df, vs_q_area_gb_cols = analysis.agg_vs_q_area(df)\n",
+    "total_df2 = pd.merge(vs_q_area_df, fit_df2, on=vs_q_area_gb_cols)\n",
     "total_df2"
    ]
   },
@@ -328,13 +337,14 @@
     "colors = plt.get_cmap('tab10')\n",
     "\n",
     "for i, row in total_df2.iterrows():\n",
-    "    plt.scatter(row['q_area'], row['success_probability'], color=colors(i))\n",
-    "    \n",
+    "    plt.errorbar(x=row['q_area'], \n",
+    "                 y=row['success_probability_mean'], \n",
+    "                 yerr=row['success_probability_std'],\n",
+    "                 color=colors(i), capsize=5, marker='o', ls='')\n",
     "    xx = np.linspace(np.min(row['q_area']), np.max(row['q_area']))\n",
     "    yy = exp_ansatz_vs_q_area(xx, a=row['a'], f=row['f'])\n",
     "    plt.plot(xx, yy, ls='--', color=colors(i),\n",
-    "             label=f'{row[\"run_id\"]}; f={row[\"f\"]:.3f}'\n",
-    "            )\n",
+    "             label=f'{row[\"run_id\"]}; f={row[\"f\"]:.3f}')\n",
     "\n",
     "\n",
     "plt.legend(loc='best')\n",

--- a/recirq/otoc/loschmidt/tilted_square_lattice/analysis.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/analysis.py
@@ -133,7 +133,7 @@ def loschmidt_results_to_dataframe(results: ExecutableGroupResult) -> pd.DataFra
     return _results_to_dataframe(results, _to_record)
 
 
-def agg_vs_macrocycle_depth(df: pd.DataFrame):
+def agg_vs_macrocycle_depth(df: pd.DataFrame) -> Tuple[pd.DataFrame, List[str]]:
     """Aggregate mean and stddev vs macrocycle depth.
 
     We use pandas group-by functionality to
@@ -207,7 +207,7 @@ def fit_vs_macrocycle_depth(df):
     return fitted_df, exp_ansatz_vs_macrocycle_depth
 
 
-def agg_vs_q_area(df: pd.DataFrame):
+def agg_vs_q_area(df: pd.DataFrame) -> Tuple[pd.DataFrame, List[str]]:
     """Aggregate mean and stddev vs quantum area.
 
     quantum area is the circuit number of qubits multiplied by its depth.

--- a/recirq/otoc/loschmidt/tilted_square_lattice/analysis.py
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/analysis.py
@@ -127,10 +127,42 @@ def loschmidt_results_to_dataframe(results: ExecutableGroupResult) -> pd.DataFra
             'instance_i': spec.instance_i,
             'n_repetitions': spec.n_repetitions,
             'success_probability': success_prob,
-            'processor_id': rt_config.processor_record.processor_id,
+            'processor_str': str(rt_config.processor_record),
         }
 
     return _results_to_dataframe(results, _to_record)
+
+
+def agg_vs_macrocycle_depth(df: pd.DataFrame):
+    """Aggregate mean and stddev vs macrocycle depth.
+
+    We use pandas group-by functionality to
+        1. Average (and compute the standard deviation) over random circuit
+           instances, holding all else constant.
+        2. Group these averaged quantities vs. macrocycle_depth for plotting by row.
+
+    This aggregation uses `groupby_all_except` as a wrapper around `pd.DataFrame.groupby` so we
+    can specify what we _don't_ want to aggregate over, making this function robust to the
+    introduction of new columns.
+
+    Args:
+        df: The dataframe from `loschmidt_results_to_dataframe`.
+
+    Returns:
+        vs_depth_df: A new, aggregated dataframe.
+        vs_depth_gb_cols: The named of the columns used in the final groupby operation.
+    """
+    means_df, means_gb_cols = groupby_all_except(
+        df.drop(['n_qubits', 'q_area'], axis=1),
+        y_cols=('instance_i', 'success_probability'),
+        agg_func={'success_probability': ['mean', 'std']}
+    )
+    vs_depth_df, vs_depth_gb_cols = groupby_all_except(
+        means_df,
+        y_cols=('macrocycle_depth', 'success_probability_mean', 'success_probability_std'),
+        agg_func=list
+    )
+    return vs_depth_df, vs_depth_gb_cols
 
 
 def fit_vs_macrocycle_depth(df):
@@ -173,6 +205,41 @@ def fit_vs_macrocycle_depth(df):
     fitted_df = agged.apply(_fit, axis=1) \
         .drop(y_cols, axis=1)
     return fitted_df, exp_ansatz_vs_macrocycle_depth
+
+
+def agg_vs_q_area(df: pd.DataFrame):
+    """Aggregate mean and stddev vs quantum area.
+
+    quantum area is the circuit number of qubits multiplied by its depth.
+
+    We use pandas group-by functionality to
+        1. Average (and compute the standard deviation) over random circuit
+           instances, holding all else constant.
+        2. Group these averaged quantities vs. q_area for plotting by row.
+
+    This aggregation uses `groupby_all_except` as a wrapper around `pd.DataFrame.groupby` so we
+    can specify what we _don't_ want to aggregate over, making this function robust to the
+    introduction of new columns.
+
+    Args:
+        df: The dataframe from `loschmidt_results_to_dataframe`.
+
+    Returns:
+        vs_q_area_df: A new, aggregated dataframe.
+        vs_q_area_gb_cols: The named of the columns used in the final groupby operation.
+    """
+    means_df, means_gb_cols = groupby_all_except(
+        df.drop(['width', 'height', 'n_qubits'], axis=1),
+        y_cols=('instance_i', 'success_probability'),
+        agg_func={'success_probability': ['mean', 'std']}
+    )
+    vs_q_area_df, vs_q_area_gb_cols = groupby_all_except(
+        means_df,
+        y_cols=('q_area', 'macrocycle_depth',
+                'success_probability_mean', 'success_probability_std'),
+        agg_func=list,
+    )
+    return vs_q_area_df, vs_q_area_gb_cols
 
 
 def fit_vs_q_area(df):

--- a/recirq/otoc/loschmidt/tilted_square_lattice/plots.ipynb
+++ b/recirq/otoc/loschmidt/tilted_square_lattice/plots.ipynb
@@ -1,0 +1,195 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Loschmidt Plots\n",
+    "\n",
+    "Plots for the `recirq.otoc.loschmidt.tilted_sqare_lattice` algorithmic benchmark. See the `analysis-walkthrough.ipynb` notebook for more detail into the functions used to create these plots."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "# Set up reasonable defaults for figure fonts\n",
+    "import matplotlib\n",
+    "matplotlib.rcParams.update(**{\n",
+    "    'axes.titlesize': 14,\n",
+    "    'axes.labelsize': 14,\n",
+    "    'xtick.labelsize': 12,\n",
+    "    'ytick.labelsize': 12,\n",
+    "    'legend.fontsize': 12,\n",
+    "    'legend.title_fontsize': 12,\n",
+    "    'figure.figsize': (7, 5),\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Results\n",
+    "\n",
+    "Modify the list of `run_id`s passed to `iterload_dataframes` to load datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "import cirq_google as cg\n",
+    "\n",
+    "import recirq.otoc.loschmidt.tilted_square_lattice.analysis as analysis\n",
+    "\n",
+    "def iterload_dataframes(run_ids):\n",
+    "    for run_id in run_ids:\n",
+    "        raw_results = cg.ExecutableGroupResultFilesystemRecord.from_json(run_id=run_id).load()\n",
+    "        yield analysis.loschmidt_results_to_dataframe(raw_results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.concat(list(iterload_dataframes([\n",
+    "    'simulated-1',\n",
+    "    # ...\n",
+    "])))\n",
+    "print(len(df), 'rows')\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fit vs. Macrocycle Depth\n",
+    "\n",
+    "For each topology, the success probability decays exponentially with respect to random circuit macrocycle depth. The fit parameter `f` is the layer fidelity corresponding to a random single qubit gates and entangling gates between all qubits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vs_depth_df, vs_depth_gb_cols = analysis.agg_vs_macrocycle_depth(df)\n",
+    "fit_df, exp_ansatz = analysis.fit_vs_macrocycle_depth(df)\n",
+    "total_df = pd.merge(vs_depth_df, fit_df, on=vs_depth_gb_cols)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "colors = plt.get_cmap('tab10')\n",
+    "\n",
+    "for i, row in total_df.iterrows():\n",
+    "    plt.errorbar(\n",
+    "        x=row['macrocycle_depth'],\n",
+    "        y=row['success_probability_mean'],\n",
+    "        yerr=row['success_probability_std'],\n",
+    "        marker='o', capsize=5, ls='',\n",
+    "        color=colors(i),\n",
+    "        label=f'{row[\"width\"]}x{row[\"height\"]} ({row[\"n_qubits\"]}q) {row[\"processor_str\"]}; f={row[\"f\"]:.3f}'\n",
+    "    )\n",
+    "    \n",
+    "    xx = np.linspace(np.min(row['macrocycle_depth']), np.max(row['macrocycle_depth']))\n",
+    "    yy = exp_ansatz(xx, a=row['a'], f=row['f'])\n",
+    "    plt.plot(xx, yy, ls='--', color=colors(i))\n",
+    "    \n",
+    "plt.legend(loc='best')\n",
+    "plt.yscale('log')\n",
+    "plt.xlabel('Macrocycle Depth')\n",
+    "plt.ylabel('Success Probability')\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fit vs. Quantum Area\n",
+    "\n",
+    "We define a quantity called quantum area (`q_area`) which is the circuit width (i.e. number of qubits) multiplied by its depth. This is the number of operations in the circuit (also including any idle operations). The fit parameter `f` is the per-operation, per-qubit fidelity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vs_q_area_df, vs_q_area_gb_cols = analysis.agg_vs_q_area(df)\n",
+    "fit_df2, exp_ansatz_vs_q_area = analysis.fit_vs_q_area(df)\n",
+    "total_df2 = pd.merge(vs_q_area_df, fit_df2, on=vs_q_area_gb_cols)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "colors = plt.get_cmap('tab10')\n",
+    "\n",
+    "for i, row in total_df2.iterrows():\n",
+    "    plt.errorbar(x=row['q_area'], \n",
+    "                 y=row['success_probability_mean'], \n",
+    "                 yerr=row['success_probability_std'],\n",
+    "                 color=colors(i), capsize=5, marker='o', ls='')\n",
+    "    \n",
+    "    xx = np.linspace(np.min(row['q_area']), np.max(row['q_area']))\n",
+    "    yy = exp_ansatz_vs_q_area(xx, a=row['a'], f=row['f'])\n",
+    "    plt.plot(xx, yy, ls='--', color=colors(i),\n",
+    "             label=f'{row[\"run_id\"]}; f={row[\"f\"]:.3f}'\n",
+    "            )\n",
+    "\n",
+    "\n",
+    "plt.legend(loc='best')\n",
+    "plt.xlabel('Quantum Area')\n",
+    "plt.ylabel('Macrocycle Fidelity')\n",
+    "plt.yscale('log')\n",
+    "plt.tight_layout()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR introduces `plots.ipynb`, which is a no-nonsense way of plotting data collected as part of the `loschmidt.tilted_square_lattice` benchmark. It is a stripped-down version of `analysis-walkthrough.ipynb`.

 - Factor out the aggregation operations explained in `analysis-walkthrough.ipynb` into the `analysis` module.
 - As part of the above, give more meaningful names to the intermediate dataframes.
 - For consistency and ease of visualizing multiple runs, plot errorbars in the vs_q_area plot instead of scatter points
 - somewhat unrelated change I'm sneaking in: use `str(processor_record)` instead of `processor_id` since SimulatedLocalProcessor's have the same processor_id as their real-life counterparts.

@verult @dstrain115 