### PR TITLE
Fix forced measurements with slide move

### DIFF
--- a/recirq/quantum_chess/quantum_board.py
+++ b/recirq/quantum_chess/quantum_board.py
@@ -344,20 +344,16 @@ class CirqBoard:
                 rtn.append(new_sample)
                 ancilla.append(new_ancilla)
                 if len(rtn) >= num_samples:
-                    self.debug_log += (
-                        f"Discarded {error_count} from error mitigation "
-                        f"{noise_count} from noise and "
-                        f"{post_count} from post-selection\n"
-                    )
-                    self.record_time("sample_with_ancilla", t0)
-                    return (rtn, ancilla)
+                    break
         else:
             rtn = [self.state] * num_samples
-            self.debug_log += (
-                f"Discarded {error_count} from error mitigation "
-                f"{noise_count} from noise and {post_count} from post-selection\n"
-            )
+
         self.record_time("sample_with_ancilla", t0)
+        self.debug_log += (
+            f"Discarded {error_count} from error mitigation "
+            f"{noise_count} from noise and "
+            f"{post_count} from post-selection\n"
+        )
         return (rtn, ancilla)
 
     def sample(self, num_samples: int) -> List[int]:

--- a/recirq/quantum_chess/quantum_board.py
+++ b/recirq/quantum_chess/quantum_board.py
@@ -682,7 +682,7 @@ class CirqBoard:
         self,
         qubit: cirq.Qid,
         measurement_outcome: Optional[int] = None,
-        invert: Optional[bool] = False,
+        invert: bool = False,
     ) -> int:
         """Adds a post-selection requirement to the circuit.
 
@@ -1110,7 +1110,7 @@ class CirqBoard:
                 ):
                     # squbit is classically true and there is only one path_qubit
                     capture_allowed = 1 - self.post_select_on(
-                        path_qubits[0], m.measurement
+                        path_qubits[0], m.measurement, invert=True
                     )
                 else:
                     self.add_entangled(squbit, tqubit)

--- a/recirq/quantum_chess/quantum_board_test.py
+++ b/recirq/quantum_chess/quantum_board_test.py
@@ -414,6 +414,26 @@ def test_blocked_slide_capture_through():
     assert success < 75
 
 
+def test_blocked_slide_capture_force_success():
+    b = simulator(0)
+    b.with_state(u.squares_to_bitboard(["f7", "f2", "g1"]))
+    did_it_move = b.perform_moves("g1^f3h3:SPLIT_JUMP:BASIC", "f7f2.m1:SLIDE:CAPTURE")
+    assert did_it_move
+    samples = b.sample(100)
+    for sample in samples:
+        assert sample == u.squares_to_bitboard(["f2", "h3"])
+
+
+def test_blocked_slide_capture_force_failure():
+    b = simulator(0)
+    b.with_state(u.squares_to_bitboard(["f7", "f2", "g1"]))
+    did_it_move = b.perform_moves("g1^f3h3:SPLIT_JUMP:BASIC", "f7f2.m0:SLIDE:CAPTURE")
+    assert not did_it_move
+    samples = b.sample(100)
+    for sample in samples:
+        assert sample == u.squares_to_bitboard(["f7", "f3", "f2"])
+
+
 # Works on all boards but is really slow
 @pytest.mark.parametrize("board", BIG_CIRQ_BOARDS)
 def test_superposition_slide_move(board):


### PR DESCRIPTION
Specifying .m0 or .m1 with a slide move blocked by 1 entangled qubit caused the measurement to be forced to go the opposite of how it should.