### PR TITLE
Bump Cirq to 0.14

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         cirq-version:
           - 'current'
-          # - 'previous'  (gh-247: Disabled 2012-12-15 for cirq.NamedTopologies)
+          - 'previous'
           - 'next'
       fail-fast: false
     steps:

--- a/dev_tools/write-ci-requirements.py
+++ b/dev_tools/write-ci-requirements.py
@@ -8,9 +8,9 @@ REPO_DIR = pathlib.Path(__file__).parent.parent.resolve()
 print('Repo dir:', REPO_DIR)
 
 CIRQ_VERSIONS = {
-    'previous': '==0.12.0',
-    'current': '==0.13.0',
-    'next': '>=0.14.0.dev',
+    'previous': '==0.13.0',
+    'current': '==0.14.0',
+    'next': '>=0.15.0.dev',
 }
 """Give names to relative Cirq versions so CI can have consistent names while versions 
 get incremented."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-cirq-core>=0.12.0
-cirq-google>=0.12.0
+cirq-core>=0.13.0
+cirq-google>=0.13.0
 # When changing Cirq requirements be sure to update dev_tools/write-ci-requirements.py
 
 seaborn


### PR DESCRIPTION
taking over from #277 

closes #247 

This should be relatively simple thanks to testing against `next` and by today's release of a compatible `pytket-cirq`.