### PR TITLE
Fix missing quote in QAOA doc

### DIFF
--- a/docs/qaoa/index.md
+++ b/docs/qaoa/index.md
@@ -12,5 +12,13 @@ to the Sherrington-Kirkpatrick model and MaxCut, both high dimensional graph
 problems for which the QAOA requires significant compilation.
 
 This module contains the code to generate QAOA circuits, execute demonstrations,
-and analyze the results. Please read on to learn about the example problems,
-compilation, analysis, and how to run the experiment end-to-end.
+and analyze the results. Please read on to learn about:
+
+*  [Example problems](./example_problems.ipynb)
+*  [Tasks](./tasks.ipynb) and compilation
+*  [Analysis](./precomputed_analysis.ipynb)
+
+See the left navigation for more information about the QAOA experiment
+and how to run it end-to-end.
+
+

--- a/docs/qaoa/index.md
+++ b/docs/qaoa/index.md
@@ -1,6 +1,6 @@
 # QAOA
 
-Combinatorial optimization problems can be solved with the quantum approximate x
+Combinatorial optimization problems can be solved with the quantum approximate
 optimization algorithm (QAOA; also known as "quantum alternating operator ansatz").
 
 We demonstrated the application of the Google Sycamore superconducting qubit

--- a/docs/qaoa/index.md
+++ b/docs/qaoa/index.md
@@ -1,16 +1,16 @@
 # QAOA
 
-Combinatorial optimization problems can be solved with the quantum approximate 
-optimization algorithm (QAOA; also known as "quantum alternating operator ansatz).
+Combinatorial optimization problems can be solved with the quantum approximate x
+optimization algorithm (QAOA; also known as "quantum alternating operator ansatz").
 
-We demonstrated the application of the Google Sycamore superconducting qubit 
+We demonstrated the application of the Google Sycamore superconducting qubit
 quantum processor to combinatorial optimization problems with the QAOA
 [arxiv:2004.04197](https://arxiv.org/abs/2004.04197).
-Like past QAOA experiments, we studied performance for problems defined on the 
-(planar) connectivity graph of our hardware; however, we also applied the QAOA 
-to the Sherrington-Kirkpatrick model and MaxCut, both high dimensional graph 
+Like past QAOA experiments, we studied performance for problems defined on the
+(planar) connectivity graph of our hardware; however, we also applied the QAOA
+to the Sherrington-Kirkpatrick model and MaxCut, both high dimensional graph
 problems for which the QAOA requires significant compilation.
 
-This module contains the code to generate QAOA circuits, execute demonstrations, 
+This module contains the code to generate QAOA circuits, execute demonstrations,
 and analyze the results. Please read on to learn about the example problems,
 compilation, analysis, and how to run the experiment end-to-end.


### PR DESCRIPTION
Fixes missing quote and gets rid of trailing whitespace in QAOA
experiment doc.