### PR TITLE
Fix pip install for rabi oscilliations

### DIFF
--- a/docs/benchmarks/rabi_oscillations.ipynb
+++ b/docs/benchmarks/rabi_oscillations.ipynb
@@ -76,7 +76,7 @@
     "except ImportError:\n",
     "    !pip install -U pip\n",
     "    !pip install --quiet cirq\n",
-    "    !pip install --quiet recirq\n",
+    "    !pip install --quiet git+https://github.com/quantumlib/ReCirq\n",
     "    import cirq\n",
     "    import recirq\n",
     "\n",


### PR DESCRIPTION
- This was pip installing recirq, which has no pypi package or release.