### PR TITLE
Update qubit set of device to use qubits instead

### DIFF
--- a/recirq/quantum_chess/circuit_transformer.py
+++ b/recirq/quantum_chess/circuit_transformer.py
@@ -396,7 +396,7 @@ class DynamicLookAheadHeuristicCircuitTransformer(CircuitTransformer):
           circuit: The circuit to transform.
         """
         initial_mapping = imu.calculate_initial_mapping(self.device, circuit)
-        updater = su.SwapUpdater(circuit, self.device.qubit_set(), initial_mapping)
+        updater = su.SwapUpdater(circuit, self.device.qubits, initial_mapping)
         return cirq.Circuit(updater.add_swaps())
 
 

--- a/recirq/quantum_chess/initial_mapping_utils.py
+++ b/recirq/quantum_chess/initial_mapping_utils.py
@@ -29,8 +29,8 @@ def build_physical_qubits_graph(
       device: The device from which to build a physical qubits graph.
     """
     g = defaultdict(list)
-    for q in device.qubit_set():
-        g[q] = [n for n in q.neighbors() if n in device.qubit_set()]
+    for q in device.qubits:
+        g[q] = [n for n in q.neighbors() if n in device.qubits]
     return g
 
 


### PR DESCRIPTION
- qubit_set() is deprecated in the new Device API.