### PR TITLE
Use explicit precision for testing unitaries

### DIFF
--- a/recirq/fermi_hubbard/decomposition_test.py
+++ b/recirq/fermi_hubbard/decomposition_test.py
@@ -62,15 +62,14 @@ def create_particle_conserving_matrix(theta: float,
                                  np.linspace(0, 2 * np.pi, 5)))
 def test_corrected_sqrt_iswap_ops(delta: float, chi: float, gamma: float
                                   ) -> None:
-
     a, b = cirq.LineQubit.range(2)
 
-    matrix = cirq.unitary(cirq.Circuit(_corrected_sqrt_iswap_ops(
+    matrix = cirq.Circuit(_corrected_sqrt_iswap_ops(
         qubits=(a, b),
         parameters=ParticleConservingParameters(
             delta=delta,
             chi=chi,
-            gamma=gamma))))
+            gamma=gamma))).unitary(qubit_order=(a, b), dtype=np.complex128)
 
     expected = create_particle_conserving_matrix(
         np.pi / 4, -delta, -chi, -gamma, 0)
@@ -80,10 +79,9 @@ def test_corrected_sqrt_iswap_ops(delta: float, chi: float, gamma: float
 
 @pytest.mark.parametrize('theta', np.linspace(0, 2 * np.pi, 5))
 def test_corr_hop_gate(theta: float) -> None:
-
     a, b = cirq.LineQubit.range(2)
 
-    matrix = cirq.unitary(cirq.Circuit(_corrected_gk_ops(
+    matrix = cirq.Circuit(_corrected_gk_ops(
         qubits=(a, b),
         angle=theta,
         phase_exponent=0.0,
@@ -91,7 +89,7 @@ def test_corr_hop_gate(theta: float) -> None:
             theta=theta,
             delta=0,
             chi=0,
-            gamma=0))))
+            gamma=0))).unitary(qubit_order=(a, b), dtype=np.complex128)
 
     expected = create_particle_conserving_matrix(theta, 0, 0, 0, 0)
 
@@ -100,10 +98,9 @@ def test_corr_hop_gate(theta: float) -> None:
 
 @pytest.mark.parametrize('cphase', np.linspace(-0.32, -0.8 * np.pi, 5))
 def test_corrected_cphase_ops(cphase: float) -> None:
-
     a, b = cirq.LineQubit.range(2)
 
-    matrix = cirq.unitary(cirq.Circuit(_corrected_cphase_ops(
+    matrix = cirq.Circuit(_corrected_cphase_ops(
         qubits=(a, b),
         angle=cphase,
         parameters=ParticleConservingParameters(
@@ -111,10 +108,8 @@ def test_corrected_cphase_ops(cphase: float) -> None:
             delta=0,
             chi=0,
             gamma=0,
-            phi=0))))
-
+            phi=0))).unitary(qubit_order=(a, b), dtype=np.complex128)
     expected = create_particle_conserving_matrix(0, 0, 0, 0, cphase)
-
     assert cirq.equal_up_to_global_phase(matrix, expected)
 
 
@@ -130,4 +125,3 @@ def test_corrected_cphase_ops_throws() -> None:
                 chi=0,
                 gamma=0,
                 phi=np.pi / 24))
-

--- a/recirq/qaoa/gates_and_compilation_test.py
+++ b/recirq/qaoa/gates_and_compilation_test.py
@@ -20,17 +20,17 @@ from recirq.qaoa.problems import random_plus_minus_1_weights
 def test_zz_swap():
     q1, q2 = cirq.LineQubit.range(2)
     circuit1 = cirq.Circuit(ZZSwap(zz_exponent=0.123).on(q1, q2))
-    u1 = circuit1.unitary()
+    u1 = circuit1.unitary(dtype=np.complex128)
     circuit2 = cirq.Circuit(
         cirq.ZZ(q1, q2) ** 0.123,
         cirq.SWAP(q1, q2)
     )
-    u2 = circuit2.unitary()
+    u2 = circuit2.unitary(dtype=np.complex128)
     circuit3 = cirq.Circuit(
         cirq.SWAP(q1, q2),
         cirq.ZZ(q1, q2) ** 0.123
     )
-    u3 = circuit3.unitary()
+    u3 = circuit3.unitary(dtype=np.complex128)
 
     np.testing.assert_allclose(u1, u2)
     np.testing.assert_allclose(u2, u3)
@@ -48,12 +48,12 @@ def test_compile_problem_unitary_to_zzswap():
     for i1, i2, w in problem.edges.data('weight'):
         circuit1.append(
             cirq.ZZPowGate(exponent=2 * gamma * w / np.pi, global_shift=-0.5).on(q[i1], q[i2]))
-    u1 = circuit1.unitary()
+    u1 = circuit1.unitary(dtype=np.complex128)
 
     circuit2 = cirq.Circuit(
         compile_problem_unitary_to_zzswap(problem_graph=problem, gamma=gamma, qubits=q),
         compile_problem_unitary_to_zzswap(problem_graph=problem, gamma=0, qubits=q))
-    u2 = circuit2.unitary()
+    u2 = circuit2.unitary(dtype=np.complex128)
     np.testing.assert_allclose(u1, u2)
 
 
@@ -64,13 +64,13 @@ def test_problem_unitary():
     problem = random_plus_minus_1_weights(problem, rs=np.random.RandomState(52))
     gamma = 0.151
     problem_unitary = ProblemUnitary(problem_graph=problem, gamma=gamma)
-    u1 = cirq.unitary(problem_unitary)
+    u1 = cirq.Circuit(problem_unitary.on(*q)).unitary(qubit_order=q, dtype=np.complex128)
 
     circuit = cirq.Circuit()
     for i1, i2, w in problem.edges.data('weight'):
         circuit.append(
             cirq.ZZPowGate(exponent=2 * gamma * w / np.pi, global_shift=-0.5).on(q[i1], q[i2]))
-    u2 = circuit.unitary()
+    u2 = circuit.unitary(dtype=np.complex128)
 
     np.testing.assert_allclose(u1, u2)
 
@@ -82,14 +82,14 @@ def test_swap_network_problem_unitary():
     problem = random_plus_minus_1_weights(problem, rs=np.random.RandomState(52))
     gamma = 0.151
     spu = SwapNetworkProblemUnitary(problem_graph=problem, gamma=gamma)
-    u1 = cirq.unitary(spu)
+    u1 = cirq.Circuit(spu.on(*q)).unitary(qubit_order=q, dtype=np.complex128)
 
     circuit = cirq.Circuit()
     for i1, i2, w in problem.edges.data('weight'):
         circuit.append(
             cirq.ZZPowGate(exponent=2 * gamma * w / np.pi, global_shift=-0.5).on(q[i1], q[i2]))
     circuit += cirq.QubitPermutationGate(list(range(n))[::-1]).on(*q)
-    u2 = circuit.unitary()
+    u2 = circuit.unitary(dtype=np.complex128)
     np.testing.assert_allclose(u1, u2)
 
 
@@ -104,8 +104,8 @@ def test_compile_problem_unitary_to_swap_network_p1():
     assert c1 != c2
     assert isinstance(c2.moments[-1].operations[0].gate, cirq.QubitPermutationGate)
 
-    u1 = c1.unitary()
-    u2 = c2.unitary()
+    u1 = c1.unitary(dtype=np.complex128)
+    u2 = c2.unitary(dtype=np.complex128)
     np.testing.assert_allclose(u1, u2)
 
 
@@ -122,8 +122,8 @@ def test_compile_problem_unitary_to_swap_network_p2():
     c2 = compile_problem_unitary_to_swap_network(c1)
     assert c1 != c2
     assert not isinstance(c2.moments[-1].operations[0].gate, cirq.QubitPermutationGate)
-    u1 = c1.unitary()
-    u2 = c2.unitary()
+    u1 = c1.unitary(dtype=np.complex128)
+    u2 = c2.unitary(dtype=np.complex128)
     np.testing.assert_allclose(u1, u2)
 
 
@@ -139,8 +139,8 @@ def test_compile_swap_network_to_zzswap():
     c3 = compile_swap_network_to_zzswap(c2)
     assert c2 != c3
 
-    u1 = c1.unitary()
-    u3 = c3.unitary()
+    u1 = c1.unitary(dtype=np.complex128)
+    u3 = c3.unitary(dtype=np.complex128)
     np.testing.assert_allclose(u1, u3)
 
 
@@ -160,8 +160,8 @@ def test_compile_sk_problem_unitary_to_zzswap_2():
     c3 = compile_swap_network_to_zzswap(c2)
     assert c2 != c3
 
-    u1 = c1.unitary()
-    u3 = c3.unitary()
+    u1 = c1.unitary(dtype=np.complex128)
+    u3 = c3.unitary(dtype=np.complex128)
     np.testing.assert_allclose(u1, u3)
 
 
@@ -206,7 +206,7 @@ def test_compile_problem_unitary_to_hardware_graph():
     c2 = compile_problem_unitary_to_hardware_graph(c1, coordinates)
     assert c1 != c2
 
-    np.testing.assert_allclose(c1.unitary(), c2.unitary())
+    np.testing.assert_allclose(c1.unitary(dtype=np.complex128), c2.unitary(dtype=np.complex128))
 
 
 def test_driver_unitary():
@@ -215,8 +215,8 @@ def test_driver_unitary():
     du = DriverUnitary(num_qubits=n, beta=0.123).on(*q)
     circuit = cirq.Circuit(cirq.rx(2 * 0.123).on_each(*q))
 
-    u1 = cirq.unitary(du)
-    u2 = cirq.unitary(circuit)
+    u1 = cirq.Circuit(du).unitary(qubit_order=q, dtype=np.complex128)
+    u2 = circuit.unitary(dtype=np.complex128)
     np.testing.assert_allclose(u1, u2)
 
 
@@ -227,9 +227,9 @@ def test_compile_driver_unitary_to_rx():
     c2 = cirq.Circuit(cirq.rx(2 * 0.123).on_each(*q))
     c3 = compile_driver_unitary_to_rx(c1)
 
-    u1 = c1.unitary()
-    u2 = c2.unitary()
-    u3 = c3.unitary()
+    u1 = c1.unitary(dtype=np.complex128)
+    u2 = c2.unitary(dtype=np.complex128)
+    u3 = c3.unitary(dtype=np.complex128)
     np.testing.assert_allclose(u1, u2)
     np.testing.assert_allclose(u1, u3)
 
@@ -239,7 +239,7 @@ def test_single_q_const_depth():
     ops = single_qubit_matrix_to_phased_x_z_const_depth(su)
     assert len(ops) == 2
     circuit = cirq.Circuit([op.on(cirq.LineQubit(1)) for op in ops])
-    u2 = circuit.unitary()
+    u2 = circuit.unitary(dtype=np.complex128)
     cirq.testing.assert_allclose_up_to_global_phase(su, u2, atol=1e-8)
 
 
@@ -255,8 +255,8 @@ def test_compile_single_qubit_gates():
     assert isinstance(c2[0].operations[0].gate, cirq.PhasedXPowGate)
     assert isinstance(c2[1].operations[0].gate, cirq.ZPowGate)
 
-    u1 = c1.unitary()
-    u2 = c2.unitary()
+    u1 = c1.unitary(dtype=np.complex128)
+    u2 = c2.unitary(dtype=np.complex128)
     cirq.testing.assert_allclose_up_to_global_phase(u1, u2, atol=1e-8)
 
 
@@ -266,8 +266,8 @@ def test_zzswap_as_syc():
     circuit = zzswap_as_syc(zzs.theta, q1, q2)
     assert len(circuit) == 3 * 3 + 2
 
-    u1 = cirq.unitary(zzs)
-    u2 = cirq.unitary(circuit)
+    u1 = cirq.Circuit(zzs.on(q1, q2)).unitary(qubit_order=(q1, q2), dtype=np.complex128)
+    u2 = circuit.unitary(dtype=np.complex128)
     cirq.testing.assert_allclose_up_to_global_phase(u1, u2, atol=1e-8)
 
 
@@ -289,8 +289,8 @@ def test_zz_as_syc():
     circuit = zz_as_syc(zz.exponent * np.pi / 2, q1, q2)
     assert len(circuit) == 3 * 2 + 2
 
-    u1 = cirq.unitary(zz)
-    u2 = cirq.unitary(circuit)
+    u1 = cirq.Circuit(zz.on(q1, q2)).unitary(qubit_order=(q1, q2), dtype=np.complex128)
+    u2 = circuit.unitary(dtype=np.complex128)
     cirq.testing.assert_allclose_up_to_global_phase(u1, u2, atol=1e-8)
 
 
@@ -329,12 +329,12 @@ def test_compile_to_syc(p):
     c5 = compile_to_syc(c4)
     validate_well_structured(c5, allow_terminal_permutations=True)
 
-    np.testing.assert_allclose(c1.unitary(), c2.unitary())
-    np.testing.assert_allclose(c1.unitary(), c3.unitary())
-    np.testing.assert_allclose(c1.unitary(), c4.unitary())
+    np.testing.assert_allclose(c1.unitary(dtype=np.complex128), c2.unitary(dtype=np.complex128))
+    np.testing.assert_allclose(c1.unitary(dtype=np.complex128), c3.unitary(dtype=np.complex128))
+    np.testing.assert_allclose(c1.unitary(dtype=np.complex128), c4.unitary(dtype=np.complex128))
     # Single qubit throws out global phase
     cirq.testing.assert_allclose_up_to_global_phase(
-        c1.unitary(), c5.unitary(), atol=1e-8)
+        c1.unitary(dtype=np.complex128), c5.unitary(dtype=np.complex128), atol=1e-8)
 
 
 @pytest.mark.parametrize("p", [1, 2, 3])

--- a/recirq/qml_lfe/circuit_blocks_test.py
+++ b/recirq/qml_lfe/circuit_blocks_test.py
@@ -54,8 +54,8 @@ _qubits = cirq.LineQubit.range(2)
     ),
 )
 def test_known_blocks_equal(known_circuit, compiled_ops):
-    desired_u = cirq.unitary(cirq.Circuit(known_circuit))
-    actual_u = cirq.unitary(cirq.Circuit(compiled_ops))
+    desired_u = cirq.Circuit(known_circuit).unitary(dtype=np.complex128)
+    actual_u = cirq.Circuit(compiled_ops).unitary(dtype=np.complex128)
     assert cirq.equal_up_to_global_phase(actual_u, desired_u)
 
 


### PR DESCRIPTION
Following https://github.com/quantumlib/Cirq/pull/5426/

This skips changes to quantum_chess directory in light of #300 