### PR TITLE
Don't need to pin h5py any more

### DIFF
--- a/recirq/hfvqe/extra-requirements.txt
+++ b/recirq/hfvqe/extra-requirements.txt
@@ -1,3 +1,1 @@
-# fix bug with openfermionpyscf https://github.com/quantumlib/ReCirq/issues/200#issuecomment-923203883
-h5py~=3.2.1
 openfermion>=1.2.0


### PR DESCRIPTION
https://github.com/quantumlib/OpenFermion-PySCF/issues/60