### PR TITLE
Change Result to ResultDict

### DIFF
--- a/recirq/engine_utils.py
+++ b/recirq/engine_utils.py
@@ -174,7 +174,7 @@ class ZerosSampler(work.Sampler):
             for _, m, _ in meas:
                 assert len(m.qubits) == 1
             results = [
-                study.Result(
+                study.ResultDict(
                     params=p,
                     measurements={gate.key: np.zeros(
                         (repetitions, 1), dtype=int)
@@ -187,7 +187,7 @@ class ZerosSampler(work.Sampler):
             n_qubits = len(op.qubits)
             k = gate.key
             results = [
-                study.Result(
+                study.ResultDict(
                     params=p,
                     measurements={k: np.zeros(
                         (repetitions, n_qubits), dtype=int)})


### PR DESCRIPTION
- Result instantiation is deprecated.  It is now an interface.
- Change references to ResultDict instead.