### PR TITLE
GridDevice migration

### DIFF
--- a/docs/benchmarks/rabi_oscillations.ipynb
+++ b/docs/benchmarks/rabi_oscillations.ipynb
@@ -465,7 +465,7 @@
    },
    "outputs": [],
    "source": [
-    "q = cirq_google.Sycamore.qubits[3]\n",
+    "q = list(cirq_google.Sycamore.metadata.qubit_set)[3]\n",
     "print(\"qubit\", repr(q))\n",
     "rabi_oscillations(sampler=secret_noise_sampler, qubit=q).plot()"
    ]

--- a/docs/guide/data_collection.ipynb
+++ b/docs/guide/data_collection.ipynb
@@ -383,7 +383,7 @@
     "            qubit=qubit,\n",
     "            resolution_factor=6,\n",
     "        )\n",
-    "        for qubit in cg.Sycamore23.qubits[:MAX_N_QUBITS]\n",
+    "        for qubit in sorted(cg.Sycamore23.metadata.qubit_set)[:MAX_N_QUBITS]\n",
     "    ]\n",
     "\n",
     "    for dc_task in data_collection_tasks:\n",

--- a/docs/qaoa/qaoa_maxcut.ipynb
+++ b/docs/qaoa/qaoa_maxcut.ipynb
@@ -139,7 +139,7 @@
     "np.random.seed(seed=11)\n",
     "\n",
     "# Identify working qubits from the device.\n",
-    "device_qubits = working_device.qubits\n",
+    "device_qubits = working_device.metadata.qubit_set\n",
     "working_qubits = sorted(device_qubits)[:12]\n",
     "\n",
     "# Populate a networkx graph with working_qubits as nodes.\n",

--- a/docs/qaoa/routing_with_tket.ipynb
+++ b/docs/qaoa/routing_with_tket.ipynb
@@ -205,7 +205,7 @@
    "source": [
     "import cirq_google as cg\n",
     "\n",
-    "dev_graph = ccr.gridqubits_to_graph_device(cg.Sycamore23.qubits)\n",
+    "dev_graph = ccr.gridqubits_to_graph_device(cg.Sycamore23.metadata.qubit_set)\n",
     "nx.draw_networkx(dev_graph)"
    ]
   },

--- a/docs/qaoa/routing_with_tket.ipynb
+++ b/docs/qaoa/routing_with_tket.ipynb
@@ -229,7 +229,7 @@
    },
    "source": [
     "### Convert to pytket `Device`\n",
-    "The provided function doesn't work with `SerializableDevice`. We use existing functionality to turn Devices into graphs to provide a more robust solution."
+    "The provided function doesn't work with `GridDevice`. We use existing functionality to turn Devices into graphs to provide a more robust solution."
    ]
   },
   {
@@ -241,7 +241,6 @@
    "outputs": [],
    "source": [
     "import pytket\n",
-    "from pytket.circuit import Node\n",
     "from recirq.qaoa.placement import _device_to_tket_device\n",
     "\n",
     "tk_circuit = pytket.extensions.cirq.cirq_to_tk(circuit)\n",

--- a/recirq/benchmarks/rep_rate/rep_rate_calculator.py
+++ b/recirq/benchmarks/rep_rate/rep_rate_calculator.py
@@ -131,10 +131,11 @@ class RepRateCalculator:
         self.print_log = ''
 
     @classmethod
-    def from_engine(cls,
-                    engine: cg.Engine,
-                    processor_id: str,
-                    gate_set: Optional[cg.SerializableGateSet] = None):
+    def from_engine(
+        cls,
+        engine: cg.Engine,
+        processor_id: str,
+    ):
         """
         Constructs a RepRateTester using a cirq_google.Engine object.
         Uses the device from the device specification from the API
@@ -145,14 +146,9 @@ class RepRateCalculator:
             gate_set: gate set to use.  Defaults to square root of iswap
             processor_id: Processor to test on.
         """
-        gate_set = gate_set or cg.SQRT_ISWAP_GATESET
-        device = engine.get_processor(processor_id).get_device(
-            gate_sets=[gate_set])
-        sampler = engine.sampler(processor_id=processor_id, gate_set=gate_set)
-        gate = cirq.ISWAP**0.5
-        if gate_set == cg.SYC_GATESET:
-            gate = cg.SYC
-        return cls(device, sampler, gate)
+        device = engine.get_processor(processor_id).get_device()
+        sampler = engine.sampler(processor_id=processor_id)
+        return cls(device, sampler, cg.SYC)
 
     def _flush_print_log(self) -> None:
         """Remove print log used for debugging."""

--- a/recirq/benchmarks/rep_rate/rep_rate_calculator.py
+++ b/recirq/benchmarks/rep_rate/rep_rate_calculator.py
@@ -119,10 +119,13 @@ class RepRateCalculator:
             sampler: Sampler to test for rep rate.
             gate: two-qubit gate to use for sample circuits.
         """
+        if device.metadata is None:
+            raise ValueError("Invalid device: device must contain metadata.")
+
         self.device = device
         self.sampler = sampler
         self.gate = gate
-        self.qubits = list(self.device.qubits)
+        self.qubits = sorted(self.device.metadata.qubit_set) if self.device.metadata is not None else []
 
         # log of print statements for testing
         self.print_log = ''

--- a/recirq/engine_utils.py
+++ b/recirq/engine_utils.py
@@ -217,7 +217,7 @@ class ZerosSampler(work.Sampler):
         return results[0]
 
 
-@dataclass(frozen=True)
+@dataclass
 class QuantumProcessor:
     """Grouping of relevant info
 

--- a/recirq/engine_utils_test.py
+++ b/recirq/engine_utils_test.py
@@ -105,6 +105,3 @@ def test_sampler_by_name():
                       cirq.Simulator)
     assert isinstance(recirq.get_sampler_by_name('Syc23-zeros'),
                       recirq.ZerosSampler)
-    assert isinstance(recirq.get_sampler_by_name('Syc23-zeros',
-                                                 gateset='sqrt-iswap'),
-                      recirq.ZerosSampler)

--- a/recirq/qaoa/placement.py
+++ b/recirq/qaoa/placement.py
@@ -59,7 +59,7 @@ def calibration_data_to_graph(calib_dict: cg.Calibration) -> nx.Graph:
 
 def _qubit_index_edges(device: cirq.Device):
     """Helper function in `_device_to_tket_device`"""
-    qubits = device.metadata.qubit_set() if device.metadata else ()
+    qubits = device.metadata.qubit_set if device.metadata else ()
     dev_graph = ccr.gridqubits_to_graph_device(qubits)
     for n1, n2 in dev_graph.edges:
         yield Node('grid', n1.row, n1.col), Node('grid', n2.row, n2.col)
@@ -643,7 +643,7 @@ def _get_device_calibration(device_name: str):
         # TODO: https://github.com/quantumlib/ReCirq/issues/14
         device_obj = recirq.get_device_obj_by_name(device_name)
         dummy_graph = ccr.gridqubits_to_graph_device(
-            device_obj.metadata.qubit_set() if device_obj.metadata is not None else ()
+            device_obj.metadata.qubit_set if device_obj.metadata is not None else ()
         )
         nx.set_edge_attributes(dummy_graph, name='weight', values=0.01)
         return dummy_graph

--- a/recirq/qaoa/placement.py
+++ b/recirq/qaoa/placement.py
@@ -51,7 +51,7 @@ def calibration_data_to_graph(calib_dict: cg.Calibration) -> nx.Graph:
 
 def _qubit_index_edges(device: cirq.Device):
     """Helper function in `_device_to_tket_device`"""
-    qubits = device.metadata.qubit_set() if device.metadata else None
+    qubits = device.metadata.qubit_set() if device.metadata else ()
     dev_graph = ccr.gridqubits_to_graph_device(qubits)
     for n1, n2 in dev_graph.edges:
         yield Node('grid', n1.row, n1.col), Node('grid', n2.row, n2.col)
@@ -634,7 +634,9 @@ def _get_device_calibration(device_name: str):
     if processor_id is None:
         # TODO: https://github.com/quantumlib/ReCirq/issues/14
         device_obj = recirq.get_device_obj_by_name(device_name)
-        dummy_graph = ccr.gridqubits_to_graph_device(device_obj.qubits)
+        dummy_graph = ccr.gridqubits_to_graph_device(
+            device_obj.metadata.qubit_set() if device_obj.metadata is not None else ()
+        )
         nx.set_edge_attributes(dummy_graph, name='weight', values=0.01)
         return dummy_graph
 

--- a/recirq/readout_scan/run-readout-scan.py
+++ b/recirq/readout_scan/run-readout-scan.py
@@ -44,7 +44,7 @@ def main():
             qubit=qubit,
             resolution_factor=6,
         )
-        for qubit in cg.Sycamore23.qubits[:MAX_N_QUBITS]
+        for qubit in sorted(cg.Sycamore23.metadata.qubit_set)[:MAX_N_QUBITS]
     ]
 
     for dc_task in data_collection_tasks:


### PR DESCRIPTION
* Migrated `device.qubits` callsites
  * A None check is added if `device` is a `cirq.Device`.
* Migrated 
* Removed gateset parameters

The first commit conflicts with https://github.com/quantumlib/ReCirq/pull/306 in that the solution is to check for `device.metadata is None` rather than requiring `GridDevice`. Either approach SGTM.

Couldn't test locally because `pytket.routing` is missing. @mpharrigan does https://github.com/quantumlib/ReCirq/pull/306 fix this?