### PR TITLE
Fix QAOA Maxcut Notebook for 1.0

### DIFF
--- a/docs/qaoa/qaoa_maxcut.ipynb
+++ b/docs/qaoa/qaoa_maxcut.ipynb
@@ -139,7 +139,7 @@
     "np.random.seed(seed=11)\n",
     "\n",
     "# Identify working qubits from the device.\n",
-    "device_qubits = working_device.qubits\n",
+    "device_qubits = working_device.metadata.qubit_set\n",
     "working_qubits = sorted(device_qubits)[:12]\n",
     "\n",
     "# Populate a networkx graph with working_qubits as nodes.\n",


### PR DESCRIPTION
- Notebook had working_device.qubits which is the old style.
- Update for Device API.