### PR TITLE
Fix some notebooks in Recirq

### DIFF
--- a/docs/qaoa/routing_with_tket.ipynb
+++ b/docs/qaoa/routing_with_tket.ipynb
@@ -130,7 +130,7 @@
    "source": [
     "from pytket.predicates import CompilationUnit, ConnectivityPredicate\n",
     "from pytket.passes import SequencePass, RoutingPass, DecomposeSwapsToCXs\n",
-    "from pytket.routing import GraphPlacement"
+    "from pytket.placement import GraphPlacement"
    ]
   },
   {
@@ -288,7 +288,7 @@
    "source": [
     "from pytket.predicates import CompilationUnit, ConnectivityPredicate\n",
     "from pytket.passes import SequencePass, RoutingPass, DecomposeSwapsToCXs, PlacementPass\n",
-    "from pytket.routing import GraphPlacement"
+    "from pytket.placement import GraphPlacement"
    ]
   },
   {

--- a/recirq/fermi_hubbard/decomposition.py
+++ b/recirq/fermi_hubbard/decomposition.py
@@ -118,7 +118,7 @@ class ConvertToNonUniformSqrtIswapGates:
                 during decomposition.
             sin_alpha_tolerance: Tolerance for sin(alpha) value as passed to
                 corrected_cphase_ops function.
-            eject_z_gates: Whether to apply the cirq.optimizers.EjectZ optimizer
+            eject_z_gates: Whether to apply the cirq.eject_z transformer
                 on the decomposed circuit. The effect of this optimization is a
                 circuit with virtual Z gates removed; only Z gates which are
                 actually realized on the Google hardware are kept.
@@ -153,8 +153,8 @@ class ConvertToNonUniformSqrtIswapGates:
                             self._decompose_cphase_echo_gate))
 
         if self._eject_z_gates:
-            cirq.optimizers.EjectZ().optimize_circuit(decomposed)
-            cirq.optimizers.DropEmptyMoments().optimize_circuit(decomposed)
+            decomposed = cirq.eject_z(decomposed)
+            decomposed = cirq.drop_empty_moments(decomposed)
 
         return decomposed
 

--- a/recirq/qaoa/gates_and_compilation.py
+++ b/recirq/qaoa/gates_and_compilation.py
@@ -478,7 +478,7 @@ def compile_driver_unitary_to_rx(circuit: cirq.Circuit, *, mutate=False):
 
 def single_qubit_matrix_to_phased_x_z_const_depth(
         mat: np.ndarray
-) -> List[cirq.SingleQubitGate]:
+) -> List[cirq.Gate]:
     """Implements a single-qubit operation with a PhasedX and Z gate.
 
     If one of the gates isn't needed, it will still be included with


### PR DESCRIPTION
- Used pytket.routing which was removed in pytket 1.0
- Fix use of deprecated cirq.optimizers.