### PR TITLE
Update docs with more Cirq 1.0 fixes

### DIFF
--- a/docs/qaoa/hardware_grid_circuits.ipynb
+++ b/docs/qaoa/hardware_grid_circuits.ipynb
@@ -577,7 +577,7 @@
    "outputs": [],
    "source": [
     "from cirq.contrib.routing import gridqubits_to_graph_device\n",
-    "device_graph = gridqubits_to_graph_device(recirq.get_device_obj_by_name('Sycamore23').qubit_set())\n",
+    "device_graph = gridqubits_to_graph_device(recirq.get_device_obj_by_name('Sycamore23').metadata..qubit_set())\n",
     "nx.draw_networkx(device_graph, pos={q: (q.row, q.col) for q in device_graph.nodes}, node_color=QRED)"
    ]
   },
@@ -590,7 +590,7 @@
    "outputs": [],
    "source": [
     "from matplotlib import pyplot as plt\n",
-    "device_graph = gridqubits_to_graph_device(recirq.get_device_obj_by_name('Sycamore23').qubit_set())\n",
+    "device_graph = gridqubits_to_graph_device(recirq.get_device_obj_by_name('Sycamore23').metadata.qubit_set())\n",
     "matcher = nx.algorithms.isomorphism.GraphMatcher(device_graph, problem.graph)\n",
     "\n",
     "# There's a \"rotational\" freedom which we remove here:\n",

--- a/docs/qaoa/hardware_grid_circuits.ipynb
+++ b/docs/qaoa/hardware_grid_circuits.ipynb
@@ -577,7 +577,7 @@
    "outputs": [],
    "source": [
     "from cirq.contrib.routing import gridqubits_to_graph_device\n",
-    "device_graph = gridqubits_to_graph_device(recirq.get_device_obj_by_name('Sycamore23').metadata..qubit_set())\n",
+    "device_graph = gridqubits_to_graph_device(recirq.get_device_obj_by_name('Sycamore23').metadata.qubit_set())\n",
     "nx.draw_networkx(device_graph, pos={q: (q.row, q.col) for q in device_graph.nodes}, node_color=QRED)"
    ]
   },

--- a/docs/qaoa/routing_with_tket.ipynb
+++ b/docs/qaoa/routing_with_tket.ipynb
@@ -469,7 +469,9 @@
    },
    "outputs": [],
    "source": [
-    "for _, op, _ in routed_circuit.findall_operations_with_gate_type(cirq.TwoQubitGate):\n",
+    "for op in routed_circuit.all_operations():\n",
+    "    if len(op.qubits) != 2:\n",
+    "        continue\n",
     "    a, b = op.qubits\n",
     "    assert a.is_adjacent(b)"
    ]

--- a/recirq/fermi_hubbard/execution.py
+++ b/recirq/fermi_hubbard/execution.py
@@ -127,6 +127,10 @@ class FermiHubbardExperiment:
     def _json_dict_(self):
         return cirq.dataclass_json_dict(self)
 
+    @classmethod
+    def _json_namespace_(cls):
+        return 'recirq'
+
 
 def save_experiment(experiment: FermiHubbardExperiment,
                     file_or_fn: Union[None, IO, pathlib.Path, str],

--- a/recirq/fermi_hubbard/execution.py
+++ b/recirq/fermi_hubbard/execution.py
@@ -53,7 +53,7 @@ class ExperimentResult:
 
     @classmethod
     def cirq_resolvers(cls) -> Dict[str, Optional[Type]]:
-        return {cls.__name__: cls}
+        return {cls.__name__: cls, f'recirq.{cls.__name__}': cls}
 
     def _json_dict_(self):
         return cirq.dataclass_json_dict(self)
@@ -88,6 +88,7 @@ class ExperimentRun:
     def cirq_resolvers(cls) -> Dict[str, Optional[Type]]:
         return {
             cls.__name__: cls,
+            f'recirq.{cls.__name__}': cls,
             **ExperimentResult.cirq_resolvers()
         }
 
@@ -120,6 +121,7 @@ class FermiHubbardExperiment:
     def cirq_resolvers(cls) -> Dict[str, Optional[Type]]:
         return {
             cls.__name__: cls,
+            f'recirq.{cls.__name__}': cls,
             **ExperimentRun.cirq_resolvers(),
             **FermiHubbardParameters.cirq_resolvers(),
         }

--- a/recirq/fermi_hubbard/layouts.py
+++ b/recirq/fermi_hubbard/layouts.py
@@ -84,7 +84,7 @@ class LineLayout:
 
     @classmethod
     def cirq_resolvers(cls) -> Dict[str, Optional[Type]]:
-        return {cls.__name__: cls}
+        return {cls.__name__: cls, f'recirq.{cls.__name__}': cls}
 
     @property
     def up_qubits(self) -> List[cirq.GridQubit]:
@@ -235,7 +235,7 @@ class ZigZagLayout:
 
     @classmethod
     def cirq_resolvers(cls) -> Dict[str, Optional[Type]]:
-        return {cls.__name__: cls}
+        return {cls.__name__: cls, f'recirq.{cls.__name__}': cls}
 
     @property
     def up_qubits(self) -> List[cirq.GridQubit]:

--- a/recirq/fermi_hubbard/parameters.py
+++ b/recirq/fermi_hubbard/parameters.py
@@ -90,7 +90,7 @@ class Hamiltonian:
 
     @classmethod
     def cirq_resolvers(cls) -> Dict[str, Optional[Type]]:
-        return {cls.__name__: cls}
+        return {cls.__name__: cls, f'recirq.{cls.__name__}': cls}
 
     @property
     def interactions_count(self) -> int:
@@ -243,7 +243,7 @@ class FixedSingleParticle(SingleParticle):
 
     @classmethod
     def cirq_resolvers(cls) -> Dict[str, Optional[Type]]:
-        return {cls.__name__: cls}
+        return {cls.__name__: cls, f'recirq.{cls.__name__}': cls}
 
     def get_amplitudes(self, sites_count: int) -> np.ndarray:
         if sites_count != len(self.amplitudes):
@@ -262,7 +262,7 @@ class UniformSingleParticle(SingleParticle):
 
     @classmethod
     def cirq_resolvers(cls) -> Dict[str, Optional[Type]]:
-        return {cls.__name__: cls}
+        return {cls.__name__: cls, f'recirq.{cls.__name__}': cls}
 
     def get_amplitudes(self, sites_count: int) -> np.ndarray:
         return np.full(sites_count, 1.0 / np.sqrt(sites_count))
@@ -310,7 +310,7 @@ class PhasedGaussianSingleParticle(SingleParticle):
 
     @classmethod
     def cirq_resolvers(cls) -> Dict[str, Optional[Type]]:
-        return {cls.__name__: cls}
+        return {cls.__name__: cls, f'recirq.{cls.__name__}': cls}
 
     def get_amplitudes(self, sites_count: int) -> np.ndarray:
         return _phased_gaussian_amplitudes(sites_count,
@@ -375,7 +375,7 @@ class FixedTrappingPotential(TrappingPotential):
 
     @classmethod
     def cirq_resolvers(cls) -> Dict[str, Optional[Type]]:
-        return {cls.__name__: cls}
+        return {cls.__name__: cls, f'recirq.{cls.__name__}': cls}
 
     def get_potential(self, sites_count: int) -> np.ndarray:
         if sites_count != len(self.potential):
@@ -397,7 +397,7 @@ class UniformTrappingPotential(TrappingPotential):
 
     @classmethod
     def cirq_resolvers(cls) -> Dict[str, Optional[Type]]:
-        return {cls.__name__: cls}
+        return {cls.__name__: cls, f'recirq.{cls.__name__}': cls}
 
     def get_potential(self, sites_count: int) -> np.ndarray:
         return np.zeros(sites_count)
@@ -442,7 +442,7 @@ class GaussianTrappingPotential(TrappingPotential):
 
     @classmethod
     def cirq_resolvers(cls) -> Dict[str, Optional[Type]]:
-        return {cls.__name__: cls}
+        return {cls.__name__: cls, f'recirq.{cls.__name__}': cls}
 
     def get_potential(self, sites_count: int) -> np.ndarray:
         def gaussian(x: int) -> float:
@@ -480,6 +480,7 @@ class IndependentChainsInitialState:
     def cirq_resolvers(cls) -> Dict[str, Optional[Type]]:
         return {
             cls.__name__: cls,
+            f'recirq.{cls.__name__}': cls,
             **FixedSingleParticle.cirq_resolvers(),
             **PhasedGaussianSingleParticle.cirq_resolvers(),
             **FixedTrappingPotential.cirq_resolvers(),
@@ -527,6 +528,7 @@ class FermiHubbardParameters:
     def cirq_resolvers(cls) -> Dict[str, Optional[Type]]:
         return {
             cls.__name__: cls,
+            f'recirq.{cls.__name__}': cls,
             **Hamiltonian.cirq_resolvers(),
             **IndependentChainsInitialState.cirq_resolvers(),
             **LineLayout.cirq_resolvers(),

--- a/recirq/fermi_hubbard/parameters.py
+++ b/recirq/fermi_hubbard/parameters.py
@@ -569,6 +569,10 @@ class FermiHubbardParameters:
     def _json_dict_(self):
         return cirq.dataclass_json_dict(self)
 
+    @classmethod
+    def _json_namespace_(cls):
+        return 'recirq'
+
 
 def _check_normalized(array: Iterable[Number]) -> None:
     if not np.isclose(np.linalg.norm(array), 1):

--- a/recirq/hfvqe/opdm_functionals.py
+++ b/recirq/hfvqe/opdm_functionals.py
@@ -100,7 +100,7 @@ class OpdmFunctional():  # testpragma: no cover
             'z': {},
             'xy_even': {},
             'xy_odd': {},
-            'qubits': [f'({q.row}, {q.col})' for q in self.qubits],
+            'qubits': [str(q) for q in self.qubits],
             'qubit_permutations': ccu.generate_permutations(len(self.qubits)),
             'circuits': circuits,
             'circuits_with_measurement': circuits_dict


### PR DESCRIPTION
- Hartree-Fock assumes str(q) == '(a, b)' but it is now 'q(a, b)'
- Remove TwoQubitGate
- Add metadata.qubit_set for device lookups.
- Add json_namespace to a few places.