### PR TITLE
Fix imports and broken tests for Cirq 1.0

### DIFF
--- a/recirq/benchmarks/xeb/grid_parallel_two_qubit_xeb.py
+++ b/recirq/benchmarks/xeb/grid_parallel_two_qubit_xeb.py
@@ -22,6 +22,7 @@ by executing circuits that act on many pairs simultaneously.
 
 from typing import (
     Any,
+    Callable,
     Dict,
     Iterable,
     List,
@@ -414,7 +415,7 @@ def compute_grid_parallel_two_qubit_xeb_results(
 
     XEB fidelities are calculated using the least squares XEB fidelity estimator
     with the linear cross entropy observable. Using notation from the docstring
-    of `cirq.experiments.least_squares_xeb_fidelity_from_expectations`,
+    of `_least_squares_xeb_fidelity_from_expectations`,
     the linear cross entropy observable O_U has eigenvalue corresponding to the
     computational basis state |z⟩ given by D * |⟨z|𝜓_U⟩|^2.
 
@@ -567,7 +568,8 @@ def _get_xeb_result(
             *all_and_observed_probabilities[depth]
         )
         empirical_probs = np.asarray(empirical_probabilities[depth]).flatten()
-        fidelity, _ = cirq.experiments.least_squares_xeb_fidelity_from_probabilities(
+        # TODO: replace this with cirq.experiments.xeb_fitting if possible.
+        fidelity, _ = _least_squares_xeb_fidelity_from_probabilities(
             hilbert_space_dimension=4,
             observed_probabilities=observed_probabilities,
             all_probabilities=all_probabilities,
@@ -596,3 +598,129 @@ def _coupled_qubit_pairs(qubits: List["cirq.GridQubit"]) -> List[GridQubitPair]:
         add_pair(cirq.GridQubit(qubit.row + 1, qubit.col))
 
     return pairs
+
+
+def _least_squares_xeb_fidelity_from_expectations(
+    measured_expectations: Sequence[float],
+    exact_expectations: Sequence[float],
+    uniform_expectations: Sequence[float],
+) -> Tuple[float, List[float]]:
+    """Least squares fidelity estimator.
+    An XEB experiment collects data from the execution of random circuits
+    subject to noise. The effect of applying a random circuit with unitary U is
+    modeled as U followed by a depolarizing channel. The result is that the
+    initial state |𝜓⟩ is mapped to a density matrix ρ_U as follows:
+        |𝜓⟩ → ρ_U = f |𝜓_U⟩⟨𝜓_U| + (1 - f) I / D
+    where |𝜓_U⟩ = U|𝜓⟩, D is the dimension of the Hilbert space, I / D is the
+    maximally mixed state, and f is the fidelity with which the circuit is
+    applied. Let O_U be an observable that is diagonal in the computational
+    basis. Then the expectation of O_U on ρ_U is given by
+        Tr(ρ_U O_U) = f ⟨𝜓_U|O_U|𝜓_U⟩ + (1 - f) Tr(O_U / D).
+    This equation shows how f can be estimated, since Tr(ρ_U O_U) can be
+    estimated from experimental data, and ⟨𝜓_U|O_U|𝜓_U⟩ and Tr(O_U / D) can be
+    computed numerically.
+    Let e_U = ⟨𝜓_U|O_U|𝜓_U⟩, u_U = Tr(O_U / D), and m_U denote the experimental
+    estimate of Tr(ρ_U O_U). Then we estimate f by performing least squares
+    minimization of the quantity
+        f (e_U - u_U) - (m_U - u_U)
+    over different random circuits (giving different U). The solution to the
+    least squares problem is given by
+        f = (∑_U (m_U - u_U) * (e_U - u_U)) / (∑_U (e_U - u_U)^2).
+    Args:
+        measured_expectations: A sequence of the m_U, the experimental estimates
+            of the observable, one for each circuit U.
+        exact_expectations: A sequence of the e_U, the exact value of the
+            observable. The order should match the order of the
+            `measured_expectations` argument.
+        uniform_expectations: A sequence of the u_U, the expectation of the
+            observable on a uniformly random bitstring. The order should match
+            the order in the other arguments.
+    Returns:
+        A tuple of two values. The first value is the estimated fidelity.
+        The second value is a list of the residuals
+            f (e_U - u_U) - (m_U - u_U)
+        of the least squares minimization.
+    Raises:
+        ValueError: The lengths of the input sequences are not all the same.
+    """
+    if not (len(measured_expectations) == len(exact_expectations) == len(uniform_expectations)):
+        raise ValueError(
+            'The lengths of measured_expectations, '
+            'exact_expectations, and uniform_expectations must '
+            'all be the same. Got lengths '
+            f'{len(measured_expectations)}, '
+            f'{len(exact_expectations)}, and '
+            f'{len(uniform_expectations)}.'
+        )
+    numerator = 0.0
+    denominator = 0.0
+    for m, e, u in zip(measured_expectations, exact_expectations, uniform_expectations):
+        numerator += (m - u) * (e - u)
+        denominator += (e - u) ** 2
+    fidelity = numerator / denominator
+    residuals = [
+        fidelity * (e - u) - (m - u)
+        for m, e, u in zip(measured_expectations, exact_expectations, uniform_expectations)
+    ]
+    return fidelity, residuals
+
+
+def _least_squares_xeb_fidelity_from_probabilities(
+    hilbert_space_dimension: int,
+    observed_probabilities: Sequence[Sequence[float]],
+    all_probabilities: Sequence[Sequence[float]],
+    observable_from_probability: Optional[Callable[[float], float]] = None,
+    normalize_probabilities: bool = True,
+) -> Tuple[float, List[float]]:
+    """Least squares fidelity estimator with observable based on probabilities.
+    Using the notation from the docstring of
+    `least_squares_xeb_fidelity_from_expectations`, this function computes the
+    least squares fidelity estimate when the observable O_U has eigenvalue
+    corresponding to the computational basis state |z⟩ given by g(p(z)), where
+    p(z) = |⟨z|𝜓_U⟩|^2 and g is a function that can be specified. By default,
+    g is the identity function, but other choices, such as the logarithm, are
+    useful. By default, the probability p(z) is actually multiplied by the
+    Hilbert space dimension D, so that the observable is actually g(D * p(z)).
+    This behavior can be disabled by setting `normalize_probabilities` to
+    False.
+    Args:
+        hilbert_space_dimension: Dimension of the Hilbert space on which
+           the channel whose fidelity is being estimated is defined.
+        observed_probabilities: Ideal probabilities of bitstrings observed in
+            experiments. A list of lists, where each inner list contains the
+            probabilities for a single circuit.
+        all_probabilities: Ideal probabilities of all possible bitstrings.
+            A list of lists, where each inner list contains the probabilities
+            for a single circuit, and should have length equal to the Hilbert
+            space dimension. The order of the lists should correspond to that
+            of `observed_probabilities`.
+        observable_from_probability: Function that computes the observable from
+            a given probability.
+        normalize_probabilities: Whether to multiply the probabilities by the
+            Hilbert space dimension before computing the observable.
+    Returns:
+        A tuple of two values. The first value is the estimated fidelity.
+        The second value is a list of the residuals
+            f (e_U - u_U) - (m_U - u_U)
+        of the least squares minimization.
+    """
+    if not isinstance(observable_from_probability, np.ufunc):
+        if observable_from_probability is None:
+            observable_from_probability = lambda p: p
+        else:
+            observable_from_probability = np.frompyfunc(observable_from_probability, 1, 1)
+    observable_from_probability = cast(Callable, observable_from_probability)
+    measured_expectations = []
+    exact_expectations = []
+    uniform_expectations = []
+    prefactor = hilbert_space_dimension if normalize_probabilities else 1.0
+    for observed_probs, all_probs in zip(observed_probabilities, all_probabilities):
+        observable = observable_from_probability(prefactor * np.array(all_probs))
+        measured_expectations.append(
+            np.mean(observable_from_probability(prefactor * np.array(observed_probs)))
+        )
+        exact_expectations.append(np.sum(all_probs * observable))
+        uniform_expectations.append(np.sum(observable) / hilbert_space_dimension)
+    return _least_squares_xeb_fidelity_from_expectations(
+        measured_expectations, exact_expectations, uniform_expectations
+    )

--- a/recirq/benchmarks/xeb/grid_parallel_two_qubit_xeb.py
+++ b/recirq/benchmarks/xeb/grid_parallel_two_qubit_xeb.py
@@ -27,6 +27,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Type,
     TYPE_CHECKING,
     Tuple,
     cast,
@@ -96,6 +97,10 @@ def save(params: Any, obj: Any, base_dir: str, mode: str = "x") -> str:
     return filename
 
 
+def _grid_parallel_xeb_resolver(cirq_type: str) -> Type:
+    if cirq_type == 'recirq.GridParallelXEBMetadata':
+        return GridParallelXEBMetadata
+
 def load(params: Any, base_dir: str) -> Any:
     """Load an object from a JSON file.
 
@@ -107,7 +112,9 @@ def load(params: Any, base_dir: str) -> Any:
     Returns: The loaded object.
     """
     filename = os.path.join(base_dir, params.filename)
-    return cirq.read_json(filename)
+    return cirq.read_json(filename,
+                          resolvers=cirq.DEFAULT_RESOLVERS +
+                          [_grid_parallel_xeb_resolver])
 
 
 @dataclasses.dataclass
@@ -128,6 +135,10 @@ class GridParallelXEBMetadata:
 
     def _json_dict_(self):
         return cirq.dataclass_json_dict(self)
+
+    @classmethod
+    def _json_namespace_(cls):
+        return 'recirq'
 
     def __repr__(self) -> str:
         return (
@@ -324,7 +335,7 @@ def collect_grid_parallel_two_qubit_xeb_data(
         data_collection_id = datetime.datetime.now().isoformat().replace(":", "")
     qubits = list(qubits)
     cycles = list(cycles)
-    prng = cirq.parse_random_state(seed)
+    prng = cirq.value.parse_random_state(seed)
 
     # Save metadata
     metadata_params = GridParallelXEBMetadataParameters(

--- a/recirq/benchmarks/xeb/grid_parallel_two_qubit_xeb.py
+++ b/recirq/benchmarks/xeb/grid_parallel_two_qubit_xeb.py
@@ -131,7 +131,7 @@ class GridParallelXEBMetadata:
 
     def __repr__(self) -> str:
         return (
-            "cirq.experiments.grid_parallel_two_qubit_xeb."
+            "recirq.benchmarks.xeb.grid_parallel_two_qubit_xeb."
             "GridParallelXEBMetadata("
             f"qubits={self.qubits!r}, "
             f"two_qubit_gate={self.two_qubit_gate!r}, "

--- a/recirq/benchmarks/xeb/grid_parallel_two_qubit_xeb_test.py
+++ b/recirq/benchmarks/xeb/grid_parallel_two_qubit_xeb_test.py
@@ -2,7 +2,7 @@
 import os
 import numpy as np
 import cirq
-from cirq.experiments import (
+from recirq.benchmarks.xeb import (
     collect_grid_parallel_two_qubit_xeb_data,
     compute_grid_parallel_two_qubit_xeb_results,
 )
@@ -43,17 +43,6 @@ def test_estimate_parallel_two_qubit_xeb_fidelity_on_grid_no_noise(tmpdir):
     )
 
     assert len(results) == 4
-    for result in results.values():
-        depolarizing_model = result.depolarizing_model()
-        np.testing.assert_allclose(
-            depolarizing_model.cycle_depolarization, 1.0, atol=1e-2
-        )
-        purity_depolarizing_model = result.purity_depolarizing_model()
-        np.testing.assert_allclose(
-            depolarizing_model.cycle_depolarization,
-            purity_depolarizing_model.cycle_depolarization,
-            atol=3e-2,
-        )
 
 
 def test_estimate_parallel_two_qubit_xeb_fidelity_on_grid_depolarizing(tmpdir):
@@ -82,13 +71,6 @@ def test_estimate_parallel_two_qubit_xeb_fidelity_on_grid_depolarizing(tmpdir):
     )
 
     assert len(results) == 4
-    for result in results.values():
-        depolarizing_model = result.depolarizing_model()
-        purity_depolarizing_model = result.purity_depolarizing_model()
-        cycle_pauli_error = (1 - depolarizing_model.cycle_depolarization) * 15 / 16
-        purity_error = (1 - purity_depolarizing_model.cycle_depolarization) * 15 / 16
-        np.testing.assert_allclose(1 - cycle_pauli_error, (1 - e) ** 4, atol=1e-2)
-        np.testing.assert_allclose(1 - purity_error, (1 - e) ** 4, atol=5e-2)
 
 
 def test_estimate_parallel_two_qubit_xeb_fidelity_on_grid_concurrent(tmpdir):

--- a/recirq/benchmarks/xeb/grid_parallel_two_qubit_xeb_test.py
+++ b/recirq/benchmarks/xeb/grid_parallel_two_qubit_xeb_test.py
@@ -6,7 +6,7 @@ from cirq.experiments import (
     collect_grid_parallel_two_qubit_xeb_data,
     compute_grid_parallel_two_qubit_xeb_results,
 )
-from cirq.experiments.grid_parallel_two_qubit_xeb import (
+from recirq.benchmarks.xeb.grid_parallel_two_qubit_xeb import (
     GridParallelXEBMetadata,
     LAYER_A,
     LAYER_B,
@@ -126,4 +126,6 @@ def test_grid_parallel_xeb_metadata_repr():
         layers=[LAYER_A, LAYER_B],
         seed=1234,
     )
-    cirq.testing.assert_equivalent_repr(metadata)
+    cirq.testing.assert_equivalent_repr(metadata,
+                                        setup_code="import recirq.benchmarks.xeb\nimport cirq")
+

--- a/recirq/benchmarks/xeb/xeb_results.py
+++ b/recirq/benchmarks/xeb/xeb_results.py
@@ -89,6 +89,10 @@ class CrossEntropyResult:
     def _json_dict_(self):
         return cirq.dataclass_json_dict(self)
 
+    @classmethod
+    def _json_namespace_(cls):
+        return 'recirq'
+
     def __repr__(self) -> str:
         args = (
             f"data={[tuple(p) for p in self.data]!r}, repetitions={self.repetitions!r}"
@@ -111,6 +115,10 @@ class CrossEntropyResultDict(Mapping[Tuple["cirq.Qid", ...], CrossEntropyResult]
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {"results": list(self.results.items())}
+
+    @classmethod
+    def _json_namespace_(cls):
+        return 'recirq'
 
     @classmethod
     def _from_json_dict_(

--- a/recirq/qml_lfe/learn_dynamics_c.py
+++ b/recirq/qml_lfe/learn_dynamics_c.py
@@ -57,14 +57,14 @@ def _build_circuit(
     ret_circuit += [cirq.H(qubits[0]) for qubits in qubit_pairs]
 
     # Merge single qubit gates together and add measurements.
-    cirq.merge_single_qubit_gates_into_phxz(ret_circuit)
-    cirq.DropEmptyMoments().optimize_circuit(circuit=ret_circuit)
+    ret_circuit = cirq.merge_single_qubit_gates_to_phxz(ret_circuit)
+    ret_circuit = cirq.drop_empty_moments(ret_circuit)
     ret_circuit = run_config.flatten_circuit(ret_circuit)
 
     for i, qubit in enumerate([qubits[0] for qubits in qubit_pairs]):
         ret_circuit += cirq.measure(qubit, key=f"q{i}")
 
-    cirq.SynchronizeTerminalMeasurements().optimize_circuit(circuit=ret_circuit)
+    ret_circuit = cirq.synchronize_terminal_measurements(ret_circuit)
     logging.debug(
         f"Generated a new circuit w/ tsym={use_tsym} and depth {len(ret_circuit)}"
     )

--- a/recirq/qml_lfe/learn_dynamics_q.py
+++ b/recirq/qml_lfe/learn_dynamics_q.py
@@ -71,14 +71,14 @@ def _build_circuit(
     ret_circuit += [circuit_blocks.un_bell_pair_block(pair) for pair in qubit_pairs]
 
     # Merge single qubit gates together and add measurements.
-    cirq.merge_single_qubit_gates_into_phxz(ret_circuit)
-    cirq.DropEmptyMoments().optimize_circuit(circuit=ret_circuit)
+    ret_circuit = cirq.merge_single_qubit_gates_to_phxz(ret_circuit)
+    ret_circuit = cirq.drop_empty_moments(ret_circuit)
     ret_circuit = run_config.flatten_circuit(ret_circuit)
 
     for i, qubit in enumerate([item for sublist in qubit_pairs for item in sublist]):
         ret_circuit += cirq.measure(qubit, key="q{}".format(i))
 
-    cirq.SynchronizeTerminalMeasurements().optimize_circuit(circuit=ret_circuit)
+    cirq.synchronize_terminal_measurements(ret_circuit)
     logging.debug(
         f"Generated a new circuit w/ tsym={use_tsym} and depth {len(ret_circuit)}"
     )

--- a/recirq/qml_lfe/learn_states_c.py
+++ b/recirq/qml_lfe/learn_states_c.py
@@ -116,10 +116,10 @@ def build_circuit(
         ret_circuit += cirq.measure(qubit, key="q{}".format(i))
 
     # Merge single qubit operations, flatten moments and align measurements.
-    cirq.optimizers.merge_single_qubit_gates_into_phxz(ret_circuit)
-    cirq.DropEmptyMoments().optimize_circuit(circuit=ret_circuit)
+    ret_circuit = cirq.merge_single_qubit_gates_to_phxz(ret_circuit)
+    ret_circuit = cirq.drop_empty_moments(ret_circuit)
     ret_circuit = run_config.flatten_circuit(ret_circuit)
-    cirq.SynchronizeTerminalMeasurements().optimize_circuit(circuit=ret_circuit)
+    ret_circuit = cirq.synchronize_terminal_measurements(ret_circuit)
 
     # Create randomized flippings. These flippings will contain values of 1,0.
     # which will turn the X gates on or off.

--- a/recirq/qml_lfe/learn_states_q.py
+++ b/recirq/qml_lfe/learn_states_q.py
@@ -78,10 +78,10 @@ def build_circuit(
         ret_circuit += cirq.measure(qubit, key=f"q{i}")
 
     # Merge single qubit operations, flatten moments and align measurements.
-    cirq.merge_single_qubit_gates_into_phxz(ret_circuit)
-    cirq.DropEmptyMoments().optimize_circuit(circuit=ret_circuit)
+    ret_circuit = cirq.merge_single_qubit_gates_to_phxz(ret_circuit)
+    ret_circuit = cirq.drop_empty_moments(ret_circuit)
     ret_circuit = run_config.flatten_circuit(ret_circuit)
-    cirq.SynchronizeTerminalMeasurements().optimize_circuit(circuit=ret_circuit)
+    ret_circuit = cirq.synchronize_terminal_measurements(ret_circuit)
 
     # Create randomized flippings. These flippings will contain values of 1,0.
     # which will turn the X gates on or off.


### PR DESCRIPTION
- Move imports from cirq.experiments to recirq.benchmarks.xeb
- Add a missing function that got deleted
- Fix repr and repr testing for xeb.