### PR TITLE
Bump testing to cirq 1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9
+
+WORKDIR /src
+
+RUN python -m pip install --upgrade pip && pip install pytest
+COPY . .
+RUN python dev_tools/write-ci-requirements.py --relative-cirq-version=current --all-extras
+RUN pip install -r ci-requirements.txt && pip install --no-deps -e .
+RUN RECIRQ_IMPORT_FAILSAFE=y pytest -v

--- a/dev_tools/write-ci-requirements.py
+++ b/dev_tools/write-ci-requirements.py
@@ -8,9 +8,9 @@ REPO_DIR = pathlib.Path(__file__).parent.parent.resolve()
 print('Repo dir:', REPO_DIR)
 
 CIRQ_VERSIONS = {
-    'previous': '==0.14.0',
-    'current': '==0.15.0',
-    'next': '>=1.0.0.dev',
+    'previous': '==0.15.0',
+    'current': '==1.0.0',
+    'next': '>=1.1.0.dev',
 }
 """Give names to relative Cirq versions so CI can have consistent names while versions 
 get incremented."""

--- a/recirq/qml_lfe/extra-requirements.txt
+++ b/recirq/qml_lfe/extra-requirements.txt
@@ -1,2 +1,1 @@
 absl-py
-numpy


### PR DESCRIPTION
 - change CI to use 1.0  as "current"
 - remove superfluous extra dep for one of the experiments
 - commit the dockerfile I use to debug this without waiting for github actions runniner