### PR TITLE
Disable publication_test.py

### DIFF
--- a/recirq/fermi_hubbard/publication_test.py
+++ b/recirq/fermi_hubbard/publication_test.py
@@ -16,7 +16,11 @@ import os
 from recirq.fermi_hubbard.publication import fetch_publication_data
 
 
-def test_fetch_publication_data():
+def try_fetch_publication_data():
+    """Tests fetching publication data from dryad.
+    
+    Note that this will not run as part of CI, to avoid external URL fetches.
+    """
     base_dir = "fermi_hubbard_data"
     fetch_publication_data(base_dir=base_dir, exclude=["trapping_3u3d"])
 


### PR DESCRIPTION
Disable publication test.

This test doesn't do much besides fetch an external URL and then check that the files exist.

However, this isn't really great as a unit test, since we shouldn't be fetching external URLs during a unit test (and, depending on network availability and other external factors, this could fail).