### PR TITLE
Fix serialization support for dataclasses

### DIFF
--- a/recirq/serialization_utils.py
+++ b/recirq/serialization_utils.py
@@ -213,8 +213,9 @@ def json_serializable_dataclass(_cls: Optional[Type] = None,
 
         cls._json_namespace_ = classmethod(lambda obj: namespace)
 
-        cls._json_dict_ = classmethod(lambda obj: cirq.obj_to_dict_helper(
-            obj, [f.name for f in dataclasses.fields(cls)]))
+        cls._json_dict_ = lambda obj: cirq.obj_to_dict_helper(
+            obj, [f.name for f in dataclasses.fields(cls)]
+        )
 
         if registry is not None:
             if namespace is not None:

--- a/recirq/serialization_utils_test.py
+++ b/recirq/serialization_utils_test.py
@@ -118,3 +118,6 @@ def test_str_and_repr():
 
 def test_json_serializable_class():
     assert TestTask._json_namespace_() == "recirq.test_task"
+    test_task = TestTask(dataset_id="duck")
+    json_text = cirq.to_json(test_task)
+    assert test_task == recirq.read_json(json_text=json_text)


### PR DESCRIPTION
`TestClass._json_dict_()` needs to be an instance method.

Fixes serialization of ReadoutScanTask in data_collection.ipynb notebook.
