### PR TITLE
Bump cirq versions

### DIFF
--- a/dev_tools/write-ci-requirements.py
+++ b/dev_tools/write-ci-requirements.py
@@ -8,9 +8,9 @@ REPO_DIR = pathlib.Path(__file__).parent.parent.resolve()
 print('Repo dir:', REPO_DIR)
 
 CIRQ_VERSIONS = {
-    'previous': '~=1.1.0',
-    'current': '~=1.2.0',
-    'next': '>=1.3.0.dev',
+    'previous': '~=1.2.0',
+    'current': '~=1.3.0',
+    'next': '>=1.4.0.dev',
 }
 """Give names to relative Cirq versions so CI can have consistent names while versions 
 get incremented."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-cirq-core>=1.1.0
-cirq-google>=1.1.0
+cirq-core>=1.2.0
+cirq-google>=1.2.0
 # When changing Cirq requirements be sure to update dev_tools/write-ci-requirements.py
 
 seaborn


### PR DESCRIPTION
cirq 1.1.0 is pretty old now and we saw a requirements failing to be met in github actions during #356. 