### PR TITLE
Update NumPy APIs that will be removed in numpy-2.0

### DIFF
--- a/recirq/hfvqe/analysis.py
+++ b/recirq/hfvqe/analysis.py
@@ -284,7 +284,7 @@ def mcweeny_purification(rho: np.ndarray,
     Returns:
         Purified density matrix.
     """
-    error = np.infty
+    error = np.inf
     new_rho = rho.copy()
     while error > threshold:
         new_rho = 3 * (new_rho @ new_rho) - 2 * (new_rho @ new_rho @ new_rho)

--- a/recirq/qcqmc/hamiltonian.py
+++ b/recirq/qcqmc/hamiltonian.py
@@ -394,6 +394,6 @@ def spinorb_from_spatial(
     return one_body_coefficients, two_body_coefficients
 
 
-def _cast_to_float(x: np.complex_, tol=1e-8) -> float:
+def _cast_to_float(x: np.complex128, tol=1e-8) -> float:
     assert np.abs(x.imag) < tol, "Large imaginary component found."
     return float(x.real)


### PR DESCRIPTION
Executed  ruff check --select NPY201 --fix ./

Ref: https://numpy.org/doc/stable/numpy_2_0_migration_guide.html
