### PR TITLE
Remove mistaken import

### DIFF
--- a/recirq/qcqmc/extra-requirements.txt
+++ b/recirq/qcqmc/extra-requirements.txt
@@ -8,5 +8,4 @@ openfermionpyscf
 pandas
 pfapack
 pyscf>=2.1.0 # For Python 3.10 compatability.
-qsim
 qsimcirq>=0.14.0


### PR DESCRIPTION
The inclusion of `qsim` in this list must be an old mistake that was covered up by the fact that until recently, `qsim` was an unrelated package on PyPI. Only `qsimcirq` is needed here.

This fixes #366 and #367.