### PR TITLE
Pin versions of 3rd-party actions and GitHub runners

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   pytest:
     name: Pytest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         cirq-version:
@@ -31,8 +31,8 @@ jobs:
           - 'next'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -60,10 +60,10 @@ jobs:
 
   nbformat:
     name: Notebook formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: '3.10'
       - name: Doc check


### PR DESCRIPTION
Google's terms for allowing the use of GitHub Actions on Google-owned repositories requires that third-party actions be referenced using a specific commit, not a tagged release or a branch name. They also recommend that GitHub-hosted runners be referenced by fixed versions and not "-latest". (Internal doc link: go/github-actions#actions)

The SHAs for GitHub Actions in this commit were obtained using [frizbee](https://github.com/stacklok/frizbee). The runner versions equivalent to the "-latest" runners are based on the table at https://github.com/actions/runner-images