### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# Summary: coding style configuration for editors that read .editorconfig.
+#
+# EditorConfig defines a file format for specifying some common coding style
+# parameters. Many editors recognize .editorconfig files automatically, and
+# there exist plugins for other editors. See https://spec.editorconfig.org/.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+spelling_language = en-US
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4
+indent_style = space
+max_line_length = 100
+
+[*.sh]
+indent_size = 4
+indent_style = space
+max_line_length = 100
+
+[*.yml,*.yaml]
+indent_size = 2


### PR DESCRIPTION
This adds settings based on some common-sense values and the ReCirq project's current conventions, such as max line length (100) and use of spaces instead of tabs.