### PR TITLE
Resolve #384: delete Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM python:3.9
-
-WORKDIR /src
-
-RUN python -m pip install --upgrade pip && pip install pytest
-COPY . .
-RUN python dev_tools/write-ci-requirements.py --relative-cirq-version=current --all-extras
-RUN pip install -r ci-requirements.txt && pip install --no-deps -e .
-RUN RECIRQ_IMPORT_FAILSAFE=y pytest -v


### PR DESCRIPTION
The `Dockerfile` found at the top level of the ReCirq repository does not appear to be used anywhere. It is likely to be an accident from a past import or addition to the ReCirq repo.

Resolves https://github.com/quantumlib/ReCirq/issues/384