### PR TITLE
Add Lattice Gauge notebook to the TOC

### DIFF
--- a/docs/_index_included.yaml
+++ b/docs/_index_included.yaml
@@ -133,5 +133,3 @@ included:
       path: /cirq/experiments/lattice_gauge/lattice_gauge
     - heading: Code Layout
 
-
-docs/lattice_gauge/lattice_gauge.ipynb

--- a/docs/_index_included.yaml
+++ b/docs/_index_included.yaml
@@ -123,3 +123,15 @@ included:
     - heading: Experimental Wavefunctions
       description: Analyze published experimental wavefunctions.
       path: /cirq/experiments/qcqmc/experimental_wavefunctions
+
+- heading: Lattice Gauge Theory
+  description: Simulations for Charges and Strings in (2+1)D Lattice Gauge Theories
+  options:
+    - cards
+  items:
+    - heading: Experiment Example
+      path: /cirq/experiments/lattice_gauge/lattice_gauge
+    - heading: Code Layout
+
+
+docs/lattice_gauge/lattice_gauge.ipynb

--- a/docs/_toc.yaml
+++ b/docs/_toc.yaml
@@ -83,3 +83,7 @@ toc:
   path: /cirq/experiments/qcqmc/full_workflow
 - title: "Experimental Wavefunctions"
   path: /cirq/experiments/qcqmc/experimental_wavefunctions
+
+- heading: "Lattice Gauge Theory"
+- title: "Simulation of Charges and Strings"
+  path: /cirq/experiments/lattice_gauge/lattice_gauge


### PR DESCRIPTION
- This adds the Lattice Gauge Theory notebook to the devsite table of contents.