### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,37 @@
+name: Bug report
+description: Report a problem with this software or project
+type: Bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this bug report!
+
+  - type: textarea
+    attributes:
+      label: Describe the issue
+      description: >-
+        Please explain clearly and in detail what the issue is. What led up
+        to it, or how did you encounter it?
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: What version of the software are you using?
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: How can the issue be reproduced?
+      description: >-
+        Explain in a step-by-step fashion what someone else would need to
+        do in order to reproduce the issue. If possible, include literal
+        examples of commands or code using [Markdown fenced code
+        blocks](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks).
+        For long output, paste the text into [collapsed
+        sections](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections)
+        or attach text files.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -16,12 +16,6 @@ body:
     validations:
       required: true
 
-  - type: input
-    attributes:
-      label: What version of the software are you using?
-    validations:
-      required: false
-
   - type: textarea
     attributes:
       label: How can the issue be reproduced?

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Request a new feature or change
+type: Enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this feature request form!
+
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a use case or problem?
+      description: >-
+        Please tell us the context of your request. Is it to help you do
+        something that you currently cannot due to limitations in the software,
+        or is it an idea for an enhancement or new functionality, or something
+        else?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: What solution or approach do you envision?
+      description: >-
+        If you have ideas or preferences for the solution, you can let us know
+        here. If you are aware of other similar or related work, please let us
+        know about it here.
+    validations:
+      required: false
+
+  - type: dropdown
+    attributes:
+      label: How urgent is this for you?
+      description: >-
+        Please choose from among the following options. If the lack of this
+        feature is blocking important work, please choose from among P0–P2.
+      options:
+        - P0 – needed no later than a week
+        - P1 – needed by the next release
+        - P2 – needed within two quarters
+        - P3 – not blocked; it's an idea
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/3-task.yml
+++ b/.github/ISSUE_TEMPLATE/3-task.yml
@@ -1,0 +1,34 @@
+name: Task
+description: Describe a task that needs to be done
+type: Task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this feature request form!
+
+  - type: textarea
+    attributes:
+      label: What is the task?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: (Optional) Do you have ideas or preferences for the approach?
+    validations:
+      required: false
+
+  - type: dropdown
+    attributes:
+      label: How urgent is this for you?
+      description: >-
+        Please choose from among the following options. If the lack of this
+        feature is blocking important work, please choose from among P0–P2.
+      options:
+        - P0 – needed no later than a week
+        - P1 – needed by the next release
+        - P2 – needed within two quarters
+        - P3 – not blocked; it's an idea
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true


### PR DESCRIPTION
This adds templates for bugs, feature requests, and tasks. These are the latest versions used in many of our other Quantumlib repos on GitHub.