### PR TITLE
Update CI work to fix #403 and make other improvements

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,6 +29,11 @@ on:
 # Declare default workflow permissions as read only.
 permissions: read-all
 
+concurrency:
+  # Cancel any previously-started but still active runs on the same branch.
+  cancel-in-progress: true
+  group: ${{github.workflow}}-${{github.event.pull_request.number||github.ref}}
+
 jobs:
   pytest:
     name: Pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          pip install --upgrade pip
           python dev_tools/write-ci-requirements.py --relative-cirq-version=${{ matrix.cirq-version }} --all-extras
           pip install -r ci-requirements.txt
           pip install --no-deps -e .
@@ -103,5 +103,6 @@ jobs:
 
       - name: Doc check
         run: |
+          pip install --upgrade pip
           pip install -r dev_tools/requirements/deps/tensorflow-docs.txt
           dev_tools/nbformat

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -47,10 +47,19 @@ jobs:
           - 'next'
       fail-fast: false
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+      - name: Check out a copy of the git repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Python with caching of pip dependencies
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.10'
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            dev_tools/requirements/deps/*.txt
+            recirq/**/extra-requirements.txt
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -79,10 +88,19 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+      - name: Check out a copy of the git repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Python with caching of pip dependencies
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.10'
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            dev_tools/requirements/deps/*.txt
+            recirq/**/extra-requirements.txt
+
       - name: Doc check
         run: |
           pip install -r dev_tools/requirements/deps/tensorflow-docs.txt

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Python package
+name: Python and notebook tests
+run-name: >-
+  Test code and/or notebooks in
+  ${{github.event_name == 'pull_request' && format('PR #{0}', github.event.pull_request.number)
+    || format('push to {0}', github.ref_name) }}
+  by @${{github.actor}}
+
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,6 +18,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 # Declare default workflow permissions as read only.
 permissions: read-all

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -26,6 +26,7 @@ jobs:
   pytest:
     name: Pytest
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       matrix:
         cirq-version:
@@ -64,6 +65,7 @@ jobs:
   nbformat:
     name: Notebook formatting
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,6 +19,9 @@ on:
   pull_request:
     branches: [ master ]
 
+# Declare default workflow permissions as read only.
+permissions: read-all
+
 jobs:
   pytest:
     name: Pytest


### PR DESCRIPTION
Changes:

* Fix issue #403: missing permissions declarations in workflow
* Add workflow job timeouts (best practice)
* Cancel any previously-running workflow jobs on same branch
* Use caching with `pip` to save time
* Rename workflow to something more intuitive
* Make it possible to invoke the workflow manually via the GUI on GitHub