### PR TITLE
Update Cirq versions in dev_tools/write-ci-requirements.py

### DIFF
--- a/dev_tools/write-ci-requirements.py
+++ b/dev_tools/write-ci-requirements.py
@@ -8,11 +8,11 @@ REPO_DIR = pathlib.Path(__file__).parent.parent.resolve()
 print('Repo dir:', REPO_DIR)
 
 CIRQ_VERSIONS = {
-    'previous': '~=1.3.0',
-    'current': '~=1.4.0',
-    'next': '>=1.5.0',
+    'previous': '~=1.4.0',
+    'current': '~=1.5.0',
+    'next': '>=1.6.0',
 }
-"""Give names to relative Cirq versions so CI can have consistent names while versions 
+"""Give names to relative Cirq versions so CI can have consistent names while versions
 get incremented."""
 
 


### PR DESCRIPTION
This updates the version numbers to the appropriate ones today.