### PR TITLE
Provide more info in the development and testing section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,18 @@ pip install -r dev_tools/requirements/deps/tensorflow-docs.txt
 Once the environment is set up, you can do your work and `git commit` your
 changes to your branch as needed.
 
-To test your code, use `pytest`. To test notebooks, run `check/nbformat`.
+To test notebooks for proper formatting and other issues, run the following
+command:
+
+```shell
+dev_tools/nbformat
+```
+
+To test your code, run
+
+```shell
+pytest recirq
+```
 
 ### Pull requests and code reviews
 


### PR DESCRIPTION
This adds text to the section on _Development and testing_, to help contributors find out about such things as the dependencies needed to run `check/nbformat`.