### PR TITLE
Fix #413: add pytest to requirements.txt

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements.txt
           python dev_tools/write-ci-requirements.py --relative-cirq-version=${{ matrix.cirq-version }} --all-extras
           pip install -r ci-requirements.txt
           pip install --no-deps -e .
@@ -52,7 +53,6 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pip install pytest
           # RECIRQ_IMPORT_FAILSAFE: skip tests on unsupported Cirq configurations
           # EXPORT_OMP_NUM_THREADS: pyscf has poor openmp performance which slows down qcqmc tests.
           export OMP_NUM_THREADS=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ seaborn
 sphinx
 ipython
 black
+pytest


### PR DESCRIPTION
Despite that there is a `pytest.ini` at the top level and that various modules in `recirq/` contain pytest-based test files, Pytest itself is not listed in `requirements.txt` nor in any requirements in `dev_tools/requirements`.

This PR adds it.

Fixes #413.