### PR TITLE
Open tutorial file using normal mode

### DIFF
--- a/recirq/documentation_utils.py
+++ b/recirq/documentation_utils.py
@@ -71,7 +71,7 @@ def fetch_guide_data_collection_data(base_dir=None):
     # Read into a BytesIO object to make it seekable
     stream_bytes = io.BytesIO(stream.read())
 
-    with tarfile.open(fileobj=stream_bytes, mode='r|xz') as tf:
+    with tarfile.open(fileobj=stream_bytes, mode='r:xz') as tf:
         for member in tf.getmembers():
             # Ensure the path being extracted is safe.
             if not os.path.abspath(os.path.join(base_dir, member.name)).startswith(


### PR DESCRIPTION
- The option 'r|xz' opens an lzma compressed stream for reading.
- This causes a StreamError: "seeking backwards is not allowed".
- This changes it to 'r:xz' which opens it as a normal file so it is seekable.
- This fixes a problem with rendering the documentation for reCirq