### PR TITLE
Check more carefully if data for data_collection notebook were fetched

### DIFF
--- a/recirq/documentation_utils.py
+++ b/recirq/documentation_utils.py
@@ -15,6 +15,7 @@
 import inspect
 import io
 import os
+import pathlib
 import re
 import tarfile
 import urllib.request
@@ -63,7 +64,8 @@ def fetch_guide_data_collection_data(base_dir=None):
     if base_dir is None:
         from recirq.readout_scan.tasks import DEFAULT_BASE_DIR as base_dir
 
-    if os.path.exists(f'{base_dir}/2020-02-tutorial'):
+    file_count = sum(1 for _ in pathlib.Path(base_dir).glob("2020-02-tutorial/Syc23-*/q-*/*.json"))
+    if file_count >= 5:
         return
 
     print("Downloading guide/data_collection data.")


### PR DESCRIPTION
Problem: Internal notebook execution for documentation webpage fails
because the data-cache directory exists in the VM, but is empty -
sponge 99d8b205-ab2d-478c-9f9f-3aba8cac0832 (failed).

Solution: Check if data-cache directory has enough files and
re-fetch the data if not.
