### PR TITLE
Fix type comparisons to use `isinstance`

### DIFF
--- a/recirq/fermi_hubbard/parameters.py
+++ b/recirq/fermi_hubbard/parameters.py
@@ -596,7 +596,7 @@ class FermiHubbardParameters:
     def equals_for_rescaling(self, other: 'FermiHubbardParameters') -> bool:
         if not isinstance(other, FermiHubbardParameters):
             return False
-        if type(self.layout) != type(other.layout):
+        if not isinstance(self.layout, type(other.layout)):
             return False
         if isinstance(self.layout, ZigZagLayout):
             interacting = not np.allclose(self.hamiltonian.u, 0.0)

--- a/recirq/fermi_hubbard/parameters.py
+++ b/recirq/fermi_hubbard/parameters.py
@@ -596,9 +596,7 @@ class FermiHubbardParameters:
     def equals_for_rescaling(self, other: 'FermiHubbardParameters') -> bool:
         if not isinstance(other, FermiHubbardParameters):
             return False
-        if not isinstance(self.layout, type(other.layout)):
-            return False
-        if isinstance(self.layout, ZigZagLayout):
+        if isinstance(self.layout, ZigZagLayout) and isinstance(other.layout, ZigZagLayout):
             interacting = not np.allclose(self.hamiltonian.u, 0.0)
             other_interacting = not np.allclose(other.hamiltonian.u, 0.0)
             return interacting == other_interacting

--- a/recirq/lattice_gauge/lattice_gauge_experiment.py
+++ b/recirq/lattice_gauge/lattice_gauge_experiment.py
@@ -601,7 +601,7 @@ def cnot_on_layer(
             cirq.Moment(cirq.CZ.on(qc, qt) for qc, qt in pairs_list),
             cirq.Moment(cirq.H.on_each(pair[1] for pair in pairs_list)),
         ]
-    elif type(depolarization_probability) == float:
+    elif isinstance(depolarization_probability, float):
         return [
             cirq.Moment(cirq.H.on_each(pair[1] for pair in pairs_list)),
             cirq.Moment(cirq.CZ.on(qc, qt) for qc, qt in pairs_list),
@@ -611,7 +611,7 @@ def cnot_on_layer(
             ),
             cirq.Moment(cirq.H.on_each(pair[1] for pair in pairs_list)),
         ]
-    elif type(depolarization_probability) == dict:
+    elif isinstance(depolarization_probability, dict):
         # make sure there is a error for every pair.
         assert set(pairs_list).intersection(set(depolarization_probability.keys())) == set(
             pairs_list
@@ -742,7 +742,7 @@ def plot_qubit_polarization_values(
 
                 qubit_index += 1
 
-    elif type(plot_physical_qubits) == list:
+    elif isinstance(plot_physical_qubits, list):
         # Plot X plaquette top qubits
         for row, col in plot_physical_qubits[0]:
             qubit_index = (row) * grid.cols + col
@@ -788,7 +788,7 @@ def plot_qubit_polarization_values(
                 get_ancilla_patch(data = ancilla_states_data, qubit_index = qubit_index,row=row, col=col, x_basis=True, ancilla_cmap = ancilla_colormap, **qubit_kwargs)
                 )
 
-    elif type(plot_ancillas) == list:
+    elif isinstance(plot_ancillas, list):
         for row, col in plot_ancillas[0]:
             ax.add_patch(
                 get_ancilla_patch(row=row, col=col, x_basis=False, **qubit_kwargs)

--- a/recirq/seniority_zero/data_processing/general.py
+++ b/recirq/seniority_zero/data_processing/general.py
@@ -267,7 +267,7 @@ def get_ls_echo_fidelity(
         postselect [bool]: whether or not to give the fidelity with
             postselection on half-filling.
     """
-    if type(frame) == cirq.Result:
+    if isinstance(frame, cirq.Result):
         return get_ls_echo_fidelity(frame.data, qubits, group, postselect)
 
     # Get the number of successful experiments
@@ -354,7 +354,7 @@ def get_signed_count_verified(
         correct_number: How many of all_qubits (excluding msmt_qubits)
             should be equal to 1.
     """
-    if type(frame) == cirq.Result:
+    if isinstance(frame, cirq.Result):
         return get_signed_count_verified(frame.data, msmt_qubits, all_qubits, correct_number)
     other_qubit_names = [str(qubit) for qubit in all_qubits if qubit not in msmt_qubits]
     qubit_names = [str(qubit) for qubit in msmt_qubits]
@@ -388,7 +388,7 @@ def get_signed_count_postselected(
         all_qubits [List[cirq.GridQubit]] : list of all qubits
         correct_number: How many of all_qubits should be equal to 1.
     """
-    if type(frame) == cirq.Result:
+    if isinstance(frame, cirq.Result):
         return get_signed_count_postselected(frame.data, msmt_qubits, all_qubits, correct_number)
     msmt_qubit_names = [str(qubit) for qubit in msmt_qubits]
     all_qubit_names = [str(qubit) for qubit in all_qubits]
@@ -416,7 +416,7 @@ def get_p0m_count_verified(
         correct_number: How many of all_qubits (excluding msmt_qubits)
             should be equal to 1.
     """
-    if type(frame) == cirq.Result:
+    if isinstance(frame, cirq.Result):
         return get_p0m_count_verified(frame.data, msmt_qubits, all_qubits, correct_number)
     other_qubit_names = [str(qubit) for qubit in all_qubits if qubit not in msmt_qubits]
     qubit_names = [str(qubit) for qubit in msmt_qubits]

--- a/recirq/seniority_zero/misc.py
+++ b/recirq/seniority_zero/misc.py
@@ -415,8 +415,8 @@ def safe_concatenate_circuits(circuit1: cirq.Circuit, circuit2: cirq.Circuit) ->
 def merge_faster(gate1: cirq.Gate, gate2: cirq.Gate, tol: Optional[float]=1e-6) -> cirq.Gate:
     """Merges single qubit gates to a phasedXZ gate, is faster than cirq when gates are rz."""
     if (
-        type(gate1.gate) == cirq.PhasedXZGate
-        and type(gate2.gate) == cirq.PhasedXZGate
+        isinstance(gate1.gate, cirq.PhasedXZGate)
+        and isinstance(gate2.gate, cirq.PhasedXZGate)
         and abs(gate2.gate.x_exponent) < tol
     ):
         new_gate = cirq.PhasedXZGate(


### PR DESCRIPTION
Some of the code used `type(X) == Y` to compare types. Those constructs lead to warnings from `flake8` because type comparisons should use `isinstance`.