### PR TITLE
Fix a subset of whitespace consistency issues

### DIFF
--- a/recirq/cluster_state_mipt/cluster_state.py
+++ b/recirq/cluster_state_mipt/cluster_state.py
@@ -38,54 +38,54 @@ def get_two_qubits_6x6(d=6):
     """
     # 6x6 grid
     if d == 6:
-        probe_qubits = [cirq.GridQubit(3,4), cirq.GridQubit(3,9)]
+        probe_qubits = [cirq.GridQubit(3, 4), cirq.GridQubit(3, 9)]
     elif d == 5:
-        probe_qubits = [cirq.GridQubit(3,4), cirq.GridQubit(3,8)]
+        probe_qubits = [cirq.GridQubit(3, 4), cirq.GridQubit(3, 8)]
         #probe_qubits = [cirq.GridQubit(3,9), cirq.GridQubit(7,9)]
     elif d == 4:
-        probe_qubits = [cirq.GridQubit(3,5), cirq.GridQubit(3,8)]
+        probe_qubits = [cirq.GridQubit(3, 5), cirq.GridQubit(3, 8)]
     elif d == 3:
-        probe_qubits = [cirq.GridQubit(3,5), cirq.GridQubit(3,7)]
+        probe_qubits = [cirq.GridQubit(3, 5), cirq.GridQubit(3, 7)]
     else:
         raise ValueError("d must be 3, 4, 5, or 6")
 
     qubits_matrix = []
-    for x in [3,4,5,6,7,8]:
+    for x in [3, 4, 5, 6, 7, 8]:
         qbs = []
-        for y in [4,5,6,7,8,9]:
-            qbs.append(cirq.GridQubit(x,y))
+        for y in [4, 5, 6, 7, 8, 9]:
+            qbs.append(cirq.GridQubit(x, y))
         qubits_matrix.append(qbs)
 
     # add ancilla pairs, [phy, anc]
     anc_pairs = [
         # top row
-        [[cirq.GridQubit(3,4), cirq.GridQubit(2,4)],
-        [cirq.GridQubit(3,5), cirq.GridQubit(2,5)],
-        [cirq.GridQubit(3,6), cirq.GridQubit(2,6)],
-        [cirq.GridQubit(3,7), cirq.GridQubit(2,7)],
-        [cirq.GridQubit(3,8), cirq.GridQubit(2,8)],
-        [cirq.GridQubit(3,9), cirq.GridQubit(2,9)],
+        [[cirq.GridQubit(3, 4), cirq.GridQubit(2, 4)],
+        [cirq.GridQubit(3, 5), cirq.GridQubit(2, 5)],
+        [cirq.GridQubit(3, 6), cirq.GridQubit(2, 6)],
+        [cirq.GridQubit(3, 7), cirq.GridQubit(2, 7)],
+        [cirq.GridQubit(3, 8), cirq.GridQubit(2, 8)],
+        [cirq.GridQubit(3, 9), cirq.GridQubit(2, 9)],
         # bottom row
-        [cirq.GridQubit(8,4), cirq.GridQubit(9,4)],
-        [cirq.GridQubit(8,5), cirq.GridQubit(9,5)],
-        [cirq.GridQubit(8,6), cirq.GridQubit(9,6)],
-        [cirq.GridQubit(8,7), cirq.GridQubit(9,7)],
-        [cirq.GridQubit(8,8), cirq.GridQubit(9,8)],
-        [cirq.GridQubit(8,9), cirq.GridQubit(9,9)],
+        [cirq.GridQubit(8, 4), cirq.GridQubit(9, 4)],
+        [cirq.GridQubit(8, 5), cirq.GridQubit(9, 5)],
+        [cirq.GridQubit(8, 6), cirq.GridQubit(9, 6)],
+        [cirq.GridQubit(8, 7), cirq.GridQubit(9, 7)],
+        [cirq.GridQubit(8, 8), cirq.GridQubit(9, 8)],
+        [cirq.GridQubit(8, 9), cirq.GridQubit(9, 9)],
         # left column
-        [cirq.GridQubit(3,4), cirq.GridQubit(3,3)],
-        [cirq.GridQubit(4,4), cirq.GridQubit(4,3)],
-        [cirq.GridQubit(5,4), cirq.GridQubit(5,3)],
-        [cirq.GridQubit(6,4), cirq.GridQubit(6,3)],
-        [cirq.GridQubit(7,4), cirq.GridQubit(7,3)],
-        [cirq.GridQubit(8,4), cirq.GridQubit(8,3)],
+        [cirq.GridQubit(3, 4), cirq.GridQubit(3, 3)],
+        [cirq.GridQubit(4, 4), cirq.GridQubit(4, 3)],
+        [cirq.GridQubit(5, 4), cirq.GridQubit(5, 3)],
+        [cirq.GridQubit(6, 4), cirq.GridQubit(6, 3)],
+        [cirq.GridQubit(7, 4), cirq.GridQubit(7, 3)],
+        [cirq.GridQubit(8, 4), cirq.GridQubit(8, 3)],
         # right column
-        [cirq.GridQubit(3,9), cirq.GridQubit(3,10)],
-        [cirq.GridQubit(4,9), cirq.GridQubit(4,10)],
-        [cirq.GridQubit(5,9), cirq.GridQubit(5,10)],
-        [cirq.GridQubit(6,9), cirq.GridQubit(6,10)],
-        [cirq.GridQubit(7,9), cirq.GridQubit(7,10)],
-        [cirq.GridQubit(8,9), cirq.GridQubit(8,10)]],
+        [cirq.GridQubit(3, 9), cirq.GridQubit(3, 10)],
+        [cirq.GridQubit(4, 9), cirq.GridQubit(4, 10)],
+        [cirq.GridQubit(5, 9), cirq.GridQubit(5, 10)],
+        [cirq.GridQubit(6, 9), cirq.GridQubit(6, 10)],
+        [cirq.GridQubit(7, 9), cirq.GridQubit(7, 10)],
+        [cirq.GridQubit(8, 9), cirq.GridQubit(8, 10)]],
         # extra ancilla pairs
         # [[cirq.GridQubit(2,8), cirq.GridQubit(1,8)]]
     ]
@@ -94,7 +94,7 @@ def get_two_qubits_6x6(d=6):
         [np.array(qubits_matrix).flatten()]+[np.array(anc_pair_set).flatten() for anc_pair_set in anc_pairs]))
     return qubits_matrix, probe_qubits, anc_pairs, all_qubits
 
-def get_circuit(qubits_matrix, theta, phi, probe_qubits, basis=[0,0], anc_pairs=[]):
+def get_circuit(qubits_matrix, theta, phi, probe_qubits, basis=[0, 0], anc_pairs=[]):
     """Create a quantum circuit for a cluster state with specified parameters.
     
     This function constructs a quantum circuit for creating a cluster state on a grid of qubits.
@@ -130,13 +130,13 @@ def get_circuit(qubits_matrix, theta, phi, probe_qubits, basis=[0,0], anc_pairs=
     # Horizontal bonds
     for i in range(num_row):
         for j in range(0, num_col-1, 2):
-            circ.append(cirq.CZ(qubits_matrix[i][j],qubits_matrix[i][j+1]))
-            circ.append(cirq.PhasedXZGate(axis_phase_exponent=0,x_exponent=0,z_exponent=-0.5).on(qubits_matrix[i][j]))
-            circ.append(cirq.PhasedXZGate(axis_phase_exponent=0,x_exponent=0,z_exponent=-0.5).on(qubits_matrix[i][j+1]))
+            circ.append(cirq.CZ(qubits_matrix[i][j], qubits_matrix[i][j+1]))
+            circ.append(cirq.PhasedXZGate(axis_phase_exponent=0, x_exponent=0, z_exponent=-0.5).on(qubits_matrix[i][j]))
+            circ.append(cirq.PhasedXZGate(axis_phase_exponent=0, x_exponent=0, z_exponent=-0.5).on(qubits_matrix[i][j+1]))
         for j in range(1, num_col-1, 2):
-            circ.append(cirq.CZ(qubits_matrix[i][j],qubits_matrix[i][j+1]))
-            circ.append(cirq.PhasedXZGate(axis_phase_exponent=0,x_exponent=0,z_exponent=-0.5).on(qubits_matrix[i][j]))
-            circ.append(cirq.PhasedXZGate(axis_phase_exponent=0,x_exponent=0,z_exponent=-0.5).on(qubits_matrix[i][j+1]))
+            circ.append(cirq.CZ(qubits_matrix[i][j], qubits_matrix[i][j+1]))
+            circ.append(cirq.PhasedXZGate(axis_phase_exponent=0, x_exponent=0, z_exponent=-0.5).on(qubits_matrix[i][j]))
+            circ.append(cirq.PhasedXZGate(axis_phase_exponent=0, x_exponent=0, z_exponent=-0.5).on(qubits_matrix[i][j+1]))
 
     # Vertical bonds
     for j in range(num_col):

--- a/recirq/cluster_state_mipt/data_collect.py
+++ b/recirq/cluster_state_mipt/data_collect.py
@@ -56,7 +56,7 @@ def collect_data(
     theta_range = np.linspace(0, np.pi/2, 11)
     phi = np.pi*(5/4)
 
-    for d in [3,4,5,6]:
+    for d in [3, 4, 5, 6]:
         qubits_matrix, probe_qubits, anc_pairs, all_qubits = get_two_qubits_6x6(d=d)
         for theta_idx in range(len(theta_range)):
             for iteration in range(5):

--- a/recirq/lattice_gauge/lattice_gauge_experiment.py
+++ b/recirq/lattice_gauge/lattice_gauge_experiment.py
@@ -626,7 +626,7 @@ def cnot_on_layer(
             ),
             cirq.Moment(cirq.H.on_each(pair[1] for pair in pairs_list)),
         ]
-    
+
 def excitation_sep_plaquette_input(
     plaq_data: np.ndarray, plaq_rows: int = 3, plaq_cols: int = 2
 ) -> np.ndarray:
@@ -659,9 +659,9 @@ def excitation_sep_plaquette_input(
     return distances
 
 def plot_qubit_polarization_values(
-    grid:LGTGrid,
+    grid: LGTGrid,
     qubit_polarization_data: np.ndarray,
-    ancilla_states_data:np.ndarray,
+    ancilla_states_data: np.ndarray,
     ax: plt.Axes | None = None,
     qubit_kwargs: dict[str, Any] | None = None,
     set_axis_off: bool = True,
@@ -698,10 +698,10 @@ def plot_qubit_polarization_values(
     qubit_order = []
     for row in range(grid.rows+1):
         for col in range(grid.cols):
-            qubit_order.append(*grid.u_set({grid.x_plaquette_to_x_ancilla(row,col)}))
-    for row in range(1,grid.rows+1):
+            qubit_order.append(*grid.u_set({grid.x_plaquette_to_x_ancilla(row, col)}))
+    for row in range(1, grid.rows+1):
         for col in range(grid.cols+1):
-            qubit_order.append(*grid.u_set({grid.z_plaquette_to_z_ancilla(row,col)}))
+            qubit_order.append(*grid.u_set({grid.z_plaquette_to_z_ancilla(row, col)}))
     qubit_order
 
     pols_shuffled = np.array([qubit_polarization_data[np.nonzero(np.array(grid.physical_qubits) == qubit)[0][0]] for qubit in qubit_order])
@@ -775,17 +775,17 @@ def plot_qubit_polarization_values(
                     **qubit_kwargs,
                 )
             )
-            
+
     if plot_ancillas is True:
         for row, col in grid.z_plaquette_indices:
             qubit_index = (2*grid.cols+1)*row+col
             ax.add_patch(
-                get_ancilla_patch(data = ancilla_states_data, qubit_index = qubit_index,row=row, col=col, x_basis=False, ancilla_cmap = ancilla_colormap, **qubit_kwargs)
+                get_ancilla_patch(data = ancilla_states_data, qubit_index = qubit_index, row=row, col=col, x_basis=False, ancilla_cmap=ancilla_colormap, **qubit_kwargs)
             )
         for row, col in grid.x_plaquette_indices:
             qubit_index = (2*grid.cols+1)*row+3+col
             ax.add_patch(
-                get_ancilla_patch(data = ancilla_states_data, qubit_index = qubit_index,row=row, col=col, x_basis=True, ancilla_cmap = ancilla_colormap, **qubit_kwargs)
+                get_ancilla_patch(data = ancilla_states_data, qubit_index = qubit_index, row=row, col=col, x_basis=True, ancilla_cmap=ancilla_colormap, **qubit_kwargs)
                 )
 
     elif type(plot_ancillas) == list:
@@ -828,7 +828,7 @@ def get_qubit_patch_rect(
     return mpatches.Polygon(coordinates, closed=True, facecolor=color, **kwargs)
 
 def get_ancilla_patch(
-        data:np.ndarray,
+        data: np.ndarray,
         qubit_index,
         row: int,
         col: int,
@@ -855,18 +855,33 @@ def mean_field_energy(theta, Lx=5, Ly=5, Je=1., Jm=1., he=0.0):
     return energy
 
 def bitstring_to_expectation_value(
-        bitstrings:np.ndarray
+        bitstrings: np.ndarray
 )->np.ndarray:
     return -2 * bitstrings + 1
 
 def energy_from_measurements(
-        grid:LGTGrid,
-        hamiltonian_coefs:dict,
-        z_basis_results:np.ndarray,
-        x_basis_results:np.ndarray
+    grid: LGTGrid,
+    hamiltonian_coefs: dict,
+    z_basis_results: np.ndarray,
+    x_basis_results: np.ndarray,
 ) -> float:
-    return (-hamiltonian_coefs['Je'] * np.sum(np.mean(bitstring_to_expectation_value(plaquette_bitstrings(z_basis_results,grid)),axis=0))
-            -hamiltonian_coefs['Jm'] * np.sum(np.mean(bitstring_to_expectation_value(x_plaquette_bitstrings(x_basis_results,grid)),axis=0))
-            -hamiltonian_coefs['he'] * np.sum(np.mean(bitstring_to_expectation_value(z_basis_results),axis=0))
-            -hamiltonian_coefs['lambda'] * np.sum(np.mean(bitstring_to_expectation_value(x_basis_results),axis=0))
+    return (
+        -hamiltonian_coefs["Je"]
+        * np.sum(
+            np.mean(
+                bitstring_to_expectation_value(plaquette_bitstrings(z_basis_results, grid)),
+                axis=0,
+            )
+        )
+        - hamiltonian_coefs["Jm"]
+        * np.sum(
+            np.mean(
+                bitstring_to_expectation_value(x_plaquette_bitstrings(x_basis_results, grid)),
+                axis=0,
+            )
+        )
+        - hamiltonian_coefs["he"]
+        * np.sum(np.mean(bitstring_to_expectation_value(z_basis_results), axis=0))
+        - hamiltonian_coefs["lambda"]
+        * np.sum(np.mean(bitstring_to_expectation_value(x_basis_results), axis=0))
     )

--- a/recirq/lattice_gauge/lattice_gauge_experiment_test.py
+++ b/recirq/lattice_gauge/lattice_gauge_experiment_test.py
@@ -63,7 +63,7 @@ def test_variational_ground_state_minimal_qubits():
     )
 
     # Define Hamiltonian coefficients
-    hamiltonian_coefs = {'Je': np.random.random(), 'Jm': np.random.random(), 'he':np.random.random(), 'lambda': np.random.random()}
+    hamiltonian_coefs = {'Je': np.random.random(), 'Jm': np.random.random(), 'he': np.random.random(), 'lambda': np.random.random()}
 
     # Define thetas to test
     thetas = [0, np.pi / 2]
@@ -78,20 +78,20 @@ def test_variational_ground_state_minimal_qubits():
         circuit = cirq.Circuit.from_moments(
             *variational_ground_state_minimal_qubits(grid, theta)
         )
-        
+
         observable = cirq.PauliSum()
         for row in range(lx):
             for col in range(ly):
-                observable += cirq.PauliString(hamiltonian_coefs['Je'],cirq.Z.on_each(grid.z_plaquette_to_physical_qubits(row, col).values()))
+                observable += cirq.PauliString(hamiltonian_coefs['Je'], cirq.Z.on_each(grid.z_plaquette_to_physical_qubits(row, col).values()))
         for row in range(lx-1):
             for col in range(ly-1):
-                observable += cirq.PauliString(hamiltonian_coefs['Jm'],cirq.X.on_each(grid.x_plaquette_to_physical_qubits(row, col).values()))
+                observable += cirq.PauliString(hamiltonian_coefs['Jm'], cirq.X.on_each(grid.x_plaquette_to_physical_qubits(row, col).values()))
         for qubit in grid.physical_qubits:
-            observable += cirq.PauliString(hamiltonian_coefs['he'],cirq.Z(qubit))
-            observable += cirq.PauliString(hamiltonian_coefs['lambda'],cirq.X(qubit))
+            observable += cirq.PauliString(hamiltonian_coefs['he'], cirq.Z(qubit))
+            observable += cirq.PauliString(hamiltonian_coefs['lambda'], cirq.X(qubit))
 
         # Simulate the expectation values
-        results = simulator.simulate_expectation_values(circuit,[observable])
+        results = simulator.simulate_expectation_values(circuit, [observable])
 
         if theta == np.pi:
             assert np.isclose(results[0], lx*ly*hamiltonian_coefs['Je']+(lx-1)*(ly-1)*hamiltonian_coefs['Jm'], atol=1e-2), (
@@ -114,7 +114,7 @@ def test_trotter_step_minimal_qubits():
     )
 
     # Define Hamiltonian coefficients
-    hamiltonian_coefs = {'Je': 1, 'Jm': 1, 'he':0.4, 'lambda': 0.5}
+    hamiltonian_coefs = {'Je': 1, 'Jm': 1, 'he': 0.4, 'lambda': 0.5}
     dt = 0.3
 
     observable = cirq.PauliSum()
@@ -123,14 +123,22 @@ def test_trotter_step_minimal_qubits():
     #WALA state after 20 Trotter steps is consistent with the expected value of 0.9019627769788106.
     for row in range(lx):
         for col in range(ly):
-            observable += cirq.PauliString(1/6,cirq.Z.on_each(grid.z_plaquette_to_physical_qubits(row, col).values()))
+            observable += cirq.PauliString(1/6, cirq.Z.on_each(grid.z_plaquette_to_physical_qubits(row, col).values()))
 
     circuit = cirq.Circuit.from_moments(
         *variational_ground_state_minimal_qubits(grid, 0.625),
-        *trotter_step_minimal_qubits(grid, dt, hamiltonian_coefs['lambda'], hamiltonian_coefs['he'], hamiltonian_coefs['Je'], hamiltonian_coefs['Jm'])*20,
+        *trotter_step_minimal_qubits(
+            grid,
+            dt,
+            hamiltonian_coefs['lambda'],
+            hamiltonian_coefs['he'],
+            hamiltonian_coefs['Je'],
+            hamiltonian_coefs['Jm'],
+        )
+        * 20,
     )
 
     simulator = qsimcirq.QSimSimulator()
-    results = simulator.simulate_expectation_values(circuit,[observable])
+    results = simulator.simulate_expectation_values(circuit, [observable])
 
     assert np.isclose(results[0], (0.9019627769788106+0j), atol=1e-4), ("Error in Trotterization circuit.")

--- a/recirq/lattice_gauge/lattice_gauge_grid_test.py
+++ b/recirq/lattice_gauge/lattice_gauge_grid_test.py
@@ -34,7 +34,7 @@ def test_z_plaquette_to_physical_qubit_indices():
     physical_qubit_indices = grid.z_plaquette_to_physical_qubit_indices(row = plaquette_index[0], col = plaquette_index[1])
 
     # Expected result based on the grid structure
-    expected_indices = [4,8,11,7]
+    expected_indices = [4, 8, 11, 7]
 
     # Assert the result matches the expected indices
     assert physical_qubit_indices == expected_indices, (

--- a/recirq/lattice_gauge/settings.py
+++ b/recirq/lattice_gauge/settings.py
@@ -30,40 +30,40 @@ BREAKING_BOTTOM = '#67cd85ff'
 BREAKING_TOP = '#e6a304ff'
 BREAKING_VAC = 'k'
 
-cmap1 = LinearSegmentedColormap.from_list("1", ['darkred', 'salmon'],gamma=1.0)
-cmap2 = LinearSegmentedColormap.from_list("2", ['salmon','lightgrey'],gamma=1.0)
-cmap3 = LinearSegmentedColormap.from_list("3", ['lightgrey','lightsteelblue'],gamma=1.0)
-cmap4 = LinearSegmentedColormap.from_list("4", ['lightsteelblue','steelblue'],gamma=1.0)
-color_list = [cmap1(i) for i in np.arange(0,1,1/375)]+ [cmap2(i) for i in np.arange(0,1,1/250)]  + [cmap3(i) for i in np.arange(0,1,1/30)] + [cmap4(i) for i in np.arange(0,1,1/95)]
-charge_cmap = LinearSegmentedColormap.from_list("Charge", color_list,gamma=1)
-charge_cmap_r = LinearSegmentedColormap.from_list("Charge_r", color_list[::-1],gamma=1)
+cmap1 = LinearSegmentedColormap.from_list("1", ['darkred', 'salmon'], gamma=1.0)
+cmap2 = LinearSegmentedColormap.from_list("2", ['salmon', 'lightgrey'], gamma=1.0)
+cmap3 = LinearSegmentedColormap.from_list("3", ['lightgrey', 'lightsteelblue'], gamma=1.0)
+cmap4 = LinearSegmentedColormap.from_list("4", ['lightsteelblue', 'steelblue'], gamma=1.0)
+color_list = [cmap1(i) for i in np.arange(0, 1, 1/375)]+ [cmap2(i) for i in np.arange(0, 1, 1/250)]  + [cmap3(i) for i in np.arange(0, 1, 1/30)] + [cmap4(i) for i in np.arange(0, 1, 1/95)]
+charge_cmap = LinearSegmentedColormap.from_list("Charge", color_list, gamma=1)
+charge_cmap_r = LinearSegmentedColormap.from_list("Charge_r", color_list[::-1], gamma=1)
 
-he_list = [0,0.3,0.6,0.8,2.0]
+he_list = [0, 0.3, 0.6, 0.8, 2.0]
 blues_cmap = matplotlib.colors.LinearSegmentedColormap.from_list(
-    "Blues", [(0.0,'k'),(0.5,'steelblue'), (1.0,(0.9*0.6901960784313725, 0.9*0.7686274509803922, 1.0*0.8705882352941177, 1.0))]
+    "Blues", [(0.0, 'k'), (0.5, 'steelblue'), (1.0, (0.9*0.6901960784313725, 0.9*0.7686274509803922, 1.0*0.8705882352941177, 1.0))]
 )
 blues_cmap_r = matplotlib.colors.LinearSegmentedColormap.from_list(
-    "Blues_r", [(1.0,'k'),(0.5,'steelblue'), (0.0,(0.9*0.6901960784313725, 0.9*0.7686274509803922, 1.0*0.8705882352941177, 1.0))][::-1]
+    "Blues_r", [(1.0, 'k'), (0.5, 'steelblue'), (0.0, (0.9*0.6901960784313725, 0.9*0.7686274509803922, 1.0*0.8705882352941177, 1.0))][::-1]
 )
-blues_color_list = [blues_cmap(i) for i in np.arange(1,-0.01,-1/(max(len(he_list)-1,1)))]
+blues_color_list = [blues_cmap(i) for i in np.arange(1, -0.01, -1/(max(len(he_list)-1, 1)))]
 
 colors_greens1 = ['white', '#009468ff']
-colors_greens2 = ["#bdc1c6",'#009468ff']
-colors_greens3 = ['#009468ff','black']
-cmap_greens1 = LinearSegmentedColormap.from_list("1", colors_greens1,gamma=3.5)
-cmap_greens2 = LinearSegmentedColormap.from_list("mycmap", colors_greens3,gamma=0.8)
-color_list = ([cmap_greens1(i) for i in np.arange(0,1,1/10240)] + [cmap_greens2(i) for i in np.arange(0,1,1/12500)])
-cmap_green = LinearSegmentedColormap.from_list("mycmap", color_list,gamma=1)
-cmap_green_r = LinearSegmentedColormap.from_list("mycmap", color_list[::-1],gamma=1)
+colors_greens2 = ["#bdc1c6", '#009468ff']
+colors_greens3 = ['#009468ff', 'black']
+cmap_greens1 = LinearSegmentedColormap.from_list("1", colors_greens1, gamma=3.5)
+cmap_greens2 = LinearSegmentedColormap.from_list("mycmap", colors_greens3, gamma=0.8)
+color_list = ([cmap_greens1(i) for i in np.arange(0, 1, 1/10240)] + [cmap_greens2(i) for i in np.arange(0, 1, 1/12500)])
+cmap_green = LinearSegmentedColormap.from_list("mycmap", color_list, gamma=1)
+cmap_green_r = LinearSegmentedColormap.from_list("mycmap", color_list[::-1], gamma=1)
 
 colors = ['darkred', 'salmon']
-cmap1 = LinearSegmentedColormap.from_list("mycmap", colors,gamma=4.0)
-colors = ['salmon','lightgrey']
-cmap2 = LinearSegmentedColormap.from_list("mycmap", colors,gamma=1.0)
-colors = ['lightgrey','lightsteelblue']
-cmap3 = LinearSegmentedColormap.from_list("mycmap", colors,gamma=1.0)
-colors = ['lightsteelblue','steelblue']
-cmap4 = LinearSegmentedColormap.from_list("mycmap", colors,gamma=0.5)
-color_list = [cmap1(i) for i in np.arange(0,1,1/1500)]+ [cmap2(i) for i in np.arange(0,1,1/300)]  + [cmap3(i) for i in np.arange(0,1,1/300)] + [cmap4(i) for i in np.arange(0,1,1/1500)]
-diff_cmap = LinearSegmentedColormap.from_list("mycmap", color_list,gamma=1)
-diff_cmap_r = LinearSegmentedColormap.from_list("mycmap", color_list[::-1],gamma=1)
+cmap1 = LinearSegmentedColormap.from_list("mycmap", colors, gamma=4.0)
+colors = ['salmon', 'lightgrey']
+cmap2 = LinearSegmentedColormap.from_list("mycmap", colors, gamma=1.0)
+colors = ['lightgrey', 'lightsteelblue']
+cmap3 = LinearSegmentedColormap.from_list("mycmap", colors, gamma=1.0)
+colors = ['lightsteelblue', 'steelblue']
+cmap4 = LinearSegmentedColormap.from_list("mycmap", colors, gamma=0.5)
+color_list = [cmap1(i) for i in np.arange(0, 1, 1/1500)]+ [cmap2(i) for i in np.arange(0, 1, 1/300)]  + [cmap3(i) for i in np.arange(0, 1, 1/300)] + [cmap4(i) for i in np.arange(0, 1, 1/1500)]
+diff_cmap = LinearSegmentedColormap.from_list("mycmap", color_list, gamma=1)
+diff_cmap_r = LinearSegmentedColormap.from_list("mycmap", color_list[::-1], gamma=1)

--- a/recirq/seniority_zero/circuits_expt/gates.py
+++ b/recirq/seniority_zero/circuits_expt/gates.py
@@ -18,7 +18,7 @@ import cirq
 import numpy as np
 
 
-def gsgate_from_sqrt_swap(q0: cirq.Qid, q1:cirq.Qid, theta: float) -> cirq.Circuit:
+def gsgate_from_sqrt_swap(q0: cirq.Qid, q1: cirq.Qid, theta: float) -> cirq.Circuit:
     """GS(theta) is a product of a Givens rotation (by theta) and a swap"""
     circuit = cirq.Circuit()
     moment_1q1 = cirq.Moment(


### PR DESCRIPTION
This adds missing spaces after commas (`,`) or colon characters:(`:`) in places where they were missing. (This was another `flake8` warning.) 

The scope of this PR is intentionally limited. It does not address other cases of missing whitespace, such as spaces around operators, where there may be questions about preferred style.