### PR TITLE
Fix #433: remove unused imports

### DIFF
--- a/recirq/benchmarks/rabi_oscillations.py
+++ b/recirq/benchmarks/rabi_oscillations.py
@@ -18,8 +18,6 @@ import sympy
 
 from matplotlib import pyplot as plt
 
-# this is for older systems with matplotlib <3.2 otherwise 3d projections fail
-from mpl_toolkits import mplot3d  # pylint: disable=unused-import
 import cirq
 
 

--- a/recirq/benchmarks/rabi_oscillations.py
+++ b/recirq/benchmarks/rabi_oscillations.py
@@ -18,6 +18,9 @@ import sympy
 
 from matplotlib import pyplot as plt
 
+# this is for older systems with matplotlib <3.2 otherwise 3d projections fail
+from mpl_toolkits import mplot3d  # pylint: disable=unused-import
+
 import cirq
 
 

--- a/recirq/benchmarks/xeb/grid_parallel_two_qubit_xeb.py
+++ b/recirq/benchmarks/xeb/grid_parallel_two_qubit_xeb.py
@@ -29,7 +29,6 @@ from typing import (
     Optional,
     Sequence,
     Type,
-    TYPE_CHECKING,
     Tuple,
     cast,
 )

--- a/recirq/cluster_state_mipt/cluster_state.py
+++ b/recirq/cluster_state_mipt/cluster_state.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import cirq
-import cirq_google as cg
 import numpy as np
 
 def get_two_qubits_6x6(d=6):

--- a/recirq/cluster_state_mipt/data_collect_test.py
+++ b/recirq/cluster_state_mipt/data_collect_test.py
@@ -18,9 +18,7 @@ import os
 import tempfile
 from unittest import mock
 
-import cirq
 import cirq_google as cg
-import numpy as np
 import pytest
 
 from recirq.cluster_state_mipt import data_collect

--- a/recirq/engine_utils.py
+++ b/recirq/engine_utils.py
@@ -17,8 +17,8 @@ import datetime
 import math
 import os
 import uuid
-from dataclasses import dataclass, field
-from typing import List, Any, Optional, Callable, Dict, Union
+from dataclasses import dataclass
+from typing import List, Any, Optional, Callable
 
 import numpy as np
 

--- a/recirq/kpz/experiment.py
+++ b/recirq/kpz/experiment.py
@@ -44,7 +44,7 @@ here they are chosen independently.
 
 """
 
-from typing import Iterator, List, Set, Tuple, Union, Optional
+from typing import Iterator, List, Union, Optional
 
 import cirq
 import numpy as np

--- a/recirq/kpz/experiment_test.py
+++ b/recirq/kpz/experiment_test.py
@@ -14,7 +14,6 @@
 
 import cirq
 import numpy as np
-import pytest
 
 from recirq.kpz import experiment as kpz
 

--- a/recirq/lattice_gauge/lattice_gauge_grid_test.py
+++ b/recirq/lattice_gauge/lattice_gauge_grid_test.py
@@ -14,8 +14,6 @@
 
 import cirq
 
-import numpy as np
-import matplotlib.pyplot as plt
 from recirq.lattice_gauge.lattice_gauge_grid import LGTGrid
 
 def test_z_plaquette_to_physical_qubit_indices():

--- a/recirq/qaoa/experiments/optimization_tasks.py
+++ b/recirq/qaoa/experiments/optimization_tasks.py
@@ -1,6 +1,5 @@
 from typing import Dict, Sequence, Optional, List, Tuple
 import os
-import shutil
 
 import numpy as np
 import cirq

--- a/recirq/qaoa/experiments/p1_landscape_tasks.py
+++ b/recirq/qaoa/experiments/p1_landscape_tasks.py
@@ -6,19 +6,14 @@ from typing import Optional, Iterable, Union, List
 import cirq
 import numpy as np
 import recirq
-from recirq.qaoa.circuit_structure import BadlyStructuredCircuitError, \
-    find_circuit_structure_violations
-from recirq.qaoa.classical_angle_optimization import OptimizationResult
-from recirq.qaoa.experiments.angle_precomputation_tasks import AnglePrecomputationTask, \
-    DEFAULT_BASE_DIR as DEFAULT_PRECOMPUTATION_BASE_DIR
 from recirq.qaoa.experiments.problem_generation_tasks import \
-    DEFAULT_BASE_DIR as DEFAULT_PROBLEM_GENERATION_BASE_DIR, ProblemGenerationTaskT, \
+    DEFAULT_PROBLEM_GENERATION_BASE_DIR, ProblemGenerationTaskT, \
     SKProblemGenerationTask
-from recirq.qaoa.gates_and_compilation import compile_to_non_negligible
 from recirq.qaoa.placement import place_line_on_device
 from recirq.qaoa.problem_circuits import get_compiled_hardware_grid_circuit, \
     get_compiled_sk_model_circuit, get_compiled_3_regular_maxcut_circuit
-from recirq.qaoa.problems import ProblemT, HardwareGridProblem, SKProblem, ThreeRegularProblem
+from recirq.qaoa.problems import HardwareGridProblem, SKProblem, ThreeRegularProblem
+
 
 EXPERIMENT_NAME = 'qaoa-p1-landscape'
 DEFAULT_BASE_DIR = os.path.expanduser(f'~/cirq-results/{EXPERIMENT_NAME}')

--- a/recirq/qaoa/experiments/precomputed_execution_tasks.py
+++ b/recirq/qaoa/experiments/precomputed_execution_tasks.py
@@ -4,7 +4,6 @@ import cirq
 import recirq
 from recirq.qaoa.circuit_structure import BadlyStructuredCircuitError, \
     find_circuit_structure_violations
-from recirq.qaoa.classical_angle_optimization import OptimizationResult
 from recirq.qaoa.experiments.angle_precomputation_tasks import AnglePrecomputationTask, \
     DEFAULT_BASE_DIR as DEFAULT_PRECOMPUTATION_BASE_DIR
 from recirq.qaoa.experiments.problem_generation_tasks import \
@@ -13,7 +12,8 @@ from recirq.qaoa.gates_and_compilation import compile_to_non_negligible
 from recirq.qaoa.placement import place_line_on_device
 from recirq.qaoa.problem_circuits import get_compiled_hardware_grid_circuit, \
     get_compiled_sk_model_circuit, get_compiled_3_regular_maxcut_circuit
-from recirq.qaoa.problems import ProblemT, HardwareGridProblem, SKProblem, ThreeRegularProblem
+from recirq.qaoa.problems import HardwareGridProblem, SKProblem, ThreeRegularProblem
+
 
 EXPERIMENT_NAME = 'qaoa-precomputed'
 DEFAULT_BASE_DIR = os.path.expanduser(f'~/cirq-results/{EXPERIMENT_NAME}')

--- a/recirq/qaoa/placement.py
+++ b/recirq/qaoa/placement.py
@@ -15,7 +15,7 @@ import cirq_google as cg
 # release containing routing is pushed and no previous Cirq releases that don't contain routing
 # are supported in ReCirq.
 try:
-    from cirq import RouteCQCC
+    from cirq import RouteCQC
 except ImportError:
     RouteCQC = NotImplemented
     try:

--- a/recirq/qaoa/placement_test.py
+++ b/recirq/qaoa/placement_test.py
@@ -15,8 +15,6 @@ from recirq.qaoa.placement import place_line_on_device, place_on_device, \
     min_weight_simple_path_anneal
 from recirq.qaoa.problem_circuits import get_generic_qaoa_circuit
 
-from recirq.qaoa.placement import pytket
-
 
 def permute_gate(qubits: Sequence[cirq.Qid], permutation: List[int]):
     return cca.LinearPermutationGate(

--- a/recirq/qcqmc/afqmc_circuits.py
+++ b/recirq/qcqmc/afqmc_circuits.py
@@ -14,9 +14,8 @@
 """Trial wavefunction circuit ansatz primitives."""
 
 import itertools
-from typing import Dict, Iterable, Iterator, List, Sequence, Tuple
+from typing import Dict, Iterable, List, Sequence, Tuple
 
-import attrs
 import cirq
 import numpy as np
 import openfermion

--- a/recirq/qcqmc/convert_to_ipie_test.py
+++ b/recirq/qcqmc/convert_to_ipie_test.py
@@ -20,7 +20,7 @@ import math
 import fqe.wavefunction as fqe_wfn
 import fqe.bitstring as fqe_bs
 
-from recirq.qcqmc import analysis, convert_to_ipie
+from recirq.qcqmc import convert_to_ipie
 
 
 def test_rotate_wavefunction_explicitly():

--- a/recirq/qcqmc/optimize_wf.py
+++ b/recirq/qcqmc/optimize_wf.py
@@ -15,7 +15,7 @@
 
 import copy
 import itertools
-from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
 
 import cirq
 import fqe

--- a/recirq/qcqmc/optimize_wf_test.py
+++ b/recirq/qcqmc/optimize_wf_test.py
@@ -14,7 +14,6 @@
 
 import fqe
 import fqe.hamiltonians.restricted_hamiltonian as fqe_hams
-import fqe.wavefunction as fqe_wfn
 import numpy as np
 import pytest
 

--- a/recirq/qml_lfe/learn_dynamics_c_test.py
+++ b/recirq/qml_lfe/learn_dynamics_c_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import pytest
 import numpy as np
 from recirq.qml_lfe import learn_dynamics_c
 

--- a/recirq/qml_lfe/learn_dynamics_q_test.py
+++ b/recirq/qml_lfe/learn_dynamics_q_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import pytest
 import numpy as np
 from recirq.qml_lfe import learn_dynamics_q
 

--- a/recirq/qml_lfe/learn_states_c_test.py
+++ b/recirq/qml_lfe/learn_states_c_test.py
@@ -1,6 +1,4 @@
 import os
-import pytest
-import tempfile
 import numpy as np
 from recirq.qml_lfe import learn_states_c
 

--- a/recirq/qml_lfe/learn_states_q_test.py
+++ b/recirq/qml_lfe/learn_states_q_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import os
 import numpy as np
 from recirq.qml_lfe import learn_states_q

--- a/recirq/qml_lfe/run_config.py
+++ b/recirq/qml_lfe/run_config.py
@@ -15,7 +15,6 @@
 """Runtime configuration items for excuting experiments on Weber (or sim)."""
 
 from typing import Dict, List
-import os
 import cirq
 import cirq_google
 

--- a/recirq/qml_lfe/run_config_test.py
+++ b/recirq/qml_lfe/run_config_test.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pytest
 import cirq
 from recirq.qml_lfe import run_config
 import numpy as np

--- a/recirq/readout_scan/run-readout-scan.py
+++ b/recirq/readout_scan/run-readout-scan.py
@@ -19,7 +19,6 @@
 
 
 from recirq.readout_scan.tasks import ReadoutScanTask, run_readout_scan
-import datetime
 import cirq_google as cg
 
 MAX_N_QUBITS = 5

--- a/recirq/serialization_utils_test.py
+++ b/recirq/serialization_utils_test.py
@@ -14,15 +14,9 @@
 
 import recirq
 
-import abc
-import inspect
 import io
-import itertools
-import textwrap
 
-import networkx as nx
 import numpy as np
-import pytest
 
 import cirq
 

--- a/recirq/time_crystals/dtc_simulation.py
+++ b/recirq/time_crystals/dtc_simulation.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Sequence, Tuple, List, Iterator
+from typing import Sequence, List, Iterator
 
 import functools
 import numpy as np

--- a/recirq/time_crystals/dtc_simulation_test.py
+++ b/recirq/time_crystals/dtc_simulation_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Tuple
+from typing import Tuple
 
 import numpy as np
 import itertools

--- a/recirq/toric_code/toric_code_state_prep_test.py
+++ b/recirq/toric_code/toric_code_state_prep_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
-
 import cirq
 import numpy as np
 import pytest


### PR DESCRIPTION
This removes unused imports across many files. The approach taken was to get a list of the unused imports using

```shell
flake8 recirq --exclude recirq/third_party --select F401
```

and then fixing the cases that it listed.