### PR TITLE
Fix minor NumPy compatibility warnings

### DIFF
--- a/recirq/hfvqe/objective_test.py
+++ b/recirq/hfvqe/objective_test.py
@@ -48,7 +48,7 @@ def get_opdm(wf, num_orbitals, transform=of.jordan_wigner):
     # not using display style objects
     for p, q in product(range(num_orbitals), repeat=2):
         operator = creation_ops[p] @ creation_ops[q].conj().transpose()
-        opdm_hw[p, q] = wf.conj().T @ operator @ wf
+        opdm_hw[p, q] = (wf.conj().T @ operator @ wf)[0, 0]
 
     return opdm_hw
 

--- a/recirq/toric_code/toric_code_plaquettes.py
+++ b/recirq/toric_code/toric_code_plaquettes.py
@@ -109,10 +109,10 @@ class ToricCodePlaquettes:
             qubit_idxs = code.z_plaquette_to_qubit_idxs(row, col)
 
         total_qubits = len(code.qubits)
-        parities = data.applymap(
+        parities = data.map(
             lambda value: cls.compute_parity(value, qubit_idxs, total_qubits)
         )
-        return float(parities.mean())
+        return float(parities.mean().iloc[0])
 
     @staticmethod
     def compute_parity(value: int, qubit_idxs: Iterable[int], total_qubits: int) -> int:


### PR DESCRIPTION
Pytest with NumPy 2.2.6 reports the following warnings:

```
recirq/hfvqe/objective_test.py:51: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    opdm_hw[p, q] = wf.conj().T @ operator @ wf

recirq/toric_code/toric_code_plaquettes.py:112: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
    parities = data.applymap(

recirq/toric_code/toric_code_plaquettes.py:115: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
    return float(parities.mean())
```

This PR makes some minor modifications to the code to get rid of the warnings.