### PR TITLE
Feature: Add Magic Square game for Contextuality demonstration

### DIFF
--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -49,9 +49,7 @@ class ContextualityResult:
         alice_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
         bob_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
 
-        alice_choices[0, :, :, 0] = self.alice_measurements[
-            0, :, :, 1
-        ]  # TODO: is this swap of 1<->0 a bug?
+        alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1]
         alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]
         alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]
         alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]
@@ -76,9 +74,7 @@ class ContextualityResult:
         alice_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
         bob_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
 
-        alice_choices[0, :, :, 0] = self.alice_measurements[
-            0, :, :, 1
-        ]  # TODO: is this swap of 1<->0 a bug?
+        alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1]
         alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]
         alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]
         alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]
@@ -111,9 +107,7 @@ class ContextualityResult:
         alice_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
         bob_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
 
-        alice_choices[0, :, :, 0] = self.alice_measurements[
-            0, :, :, 1
-        ]  # TODO: is this swap of 1<->0 a bug?
+        alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1]
         alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]
         alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]
         alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]
@@ -188,9 +182,8 @@ class ContextualityResult:
         print(f"{repetitions=}")
         for row in range(3):
             for col in range(3):
-                number_of_matches = (
-                    0  # if multiplication rules are not respected, there is no match
-                )
+                # if multiplication rules are not respected, there is no match
+                number_of_matches = 0
                 for rep in range(repetitions):
                     alice_triad = alice_choices[row, col, rep, :]
                     bob_triad = bob_choices[row, col, rep, :]
@@ -201,7 +194,7 @@ class ContextualityResult:
                 print("Times they both multi[ly correctly to +-1 =", number_of_matches)
                 win_matrix[row, col] = (
                     win_matrix[row, col] / number_of_matches
-                )  # TODO: uncomment once done with testing
+                )
         return win_matrix
 
     def get_multiply_matrix(self, game, seed: int | None = None) -> np.ndarray:

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -1,0 +1,756 @@
+# Copyright 2025 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runs the MagicSquareGame."""
+
+import dataclasses
+from typing import Any, Literal
+
+import cirq
+import numpy as np
+
+
+@dataclasses.dataclass
+class ContextualityResult:
+    """Result of the contextuality warm-up experiment.
+
+    Attributes:
+        alice_measurements: Alice's measurements. Shape is (mermin_row_alice, mermin_col_bob,
+            repetition, mermin_col).
+        bob_measurements: Bob's measurements. Shape is (mermin_row_alice, mermin_col_bob,
+            repetition, mermin_row).
+    """
+
+    alice_measurements: np.ndarray
+    bob_measurements: np.ndarray
+
+    def _select_choices_from_second_data(self) -> tuple[np.ndarray, np.ndarray]:
+        return self.alice_measurements, self.bob_measurements
+
+    def _generate_choices_from_rules_guess_3rd(self) -> tuple[np.ndarray, np.ndarray]:
+        """Generate choices from Alice and Bob's measurements by inferring the third number from the
+        first two.
+
+        Returns:
+            Alice and Bob's choices in the game.
+        """
+        repetitions = self.alice_measurements.shape[2]
+        alice_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
+        bob_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
+
+        alice_choices[0, :, :, 0] = self.alice_measurements[
+            0, :, :, 1
+        ]  # TODO: is this swap of 1<->0 a bug?
+        alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]
+        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]
+        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]
+        bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1]
+        bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0]
+        bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2]
+
+        alice_choices[:, :, :, 2] = np.sum(alice_choices, axis=3) % 2
+        bob_choices[:, :, :, 2] = 1 - (np.sum(bob_choices, axis=3) % 2)
+        return alice_choices, bob_choices
+
+    def _generate_choices_from_rules_measure_3rd_classical_multiplication(
+        self,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Generate choices from Alice and Bob's measurements by measuring
+        two one-body obserbables and making a classical multiplication to get the result
+
+        Returns:
+            Alice and Bob's choices in the game.
+        """
+        repetitions = self.alice_measurements.shape[2]
+        alice_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
+        bob_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
+
+        alice_choices[0, :, :, 0] = self.alice_measurements[
+            0, :, :, 1
+        ]  # TODO: is this swap of 1<->0 a bug?
+        alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]
+        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]
+        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]
+        bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1]
+        bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0]
+        bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2]
+
+        alice_choices[:, :, :, 2] = 1 - self.alice_measurements[:, :, :, 2]
+
+        bob_choices[:, :, :, 2] = 1 - self.bob_measurements[:, :, :, 2]
+        bob_choices[0, 0, :, 2] = self.bob_measurements[0, 0, :, 2]
+        bob_choices[0, 1, :, 2] = self.bob_measurements[0, 1, :, 2]
+        bob_choices[1, 0, :, 2] = self.bob_measurements[1, 0, :, 2]
+        bob_choices[1, 1, :, 2] = self.bob_measurements[1, 1, :, 2]
+        bob_choices[2, 0, :, 2] = self.bob_measurements[2, 0, :, 2]
+        bob_choices[2, 1, :, 2] = self.bob_measurements[2, 1, :, 2]
+
+        return alice_choices, bob_choices
+
+    def _generate_choices_from_rules_measure_3rd_quantum_multiplication(
+        self,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Generate choices from Alice and Bob's measurements by measuring
+        one two body operator for the third observable.
+
+        Returns:
+            Alice and Bob's choices in the game.
+        """
+        repetitions = self.alice_measurements.shape[2]
+        alice_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
+        bob_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
+
+        alice_choices[0, :, :, 0] = self.alice_measurements[
+            0, :, :, 1
+        ]  # TODO: is this swap of 1<->0 a bug?
+        alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]
+        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]
+        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]
+        bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1]
+        bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0]
+        bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2]
+
+        alice_choices[:, :, :, 2] = self.alice_measurements[:, :, :, 2]
+        bob_choices[:, 0, :, 2] = 1 - self.bob_measurements[:, 0, :, 2]
+        bob_choices[:, 1, :, 2] = 1 - self.bob_measurements[:, 1, :, 2]
+        bob_choices[:, 2, :, 2] = self.bob_measurements[:, 2, :, 2]
+
+        return alice_choices, bob_choices
+
+    def generate_choices(
+        self,
+        game: Literal[
+            "guess_3rd",
+            "measure_3rd_classical_multiplication",
+            "measure_3rd_quantum_multiplication",
+        ],
+        seed: int | None = None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Generate choices from Alice and Bob's measurements.
+
+        Args:
+            seed: A seed for the random number generator.
+            game:
+                guess_3rd means making two measurements and infering the third bit
+                measure_3rd_classical_multiplication: make 4 measurements for Alice and 4 for Bob.
+                get three bits out of them by mutiplying two of them toghether.
+                This corresponds to measure A and B to compute A*B.
+                measure_3rd_quantum_multiplication: make 3 measurements for Alice and 3 for Bob.
+                Use a two qubit interaction to directly measure A*B.
+
+        Returns:
+            Alice and Bob's choices in the game.
+
+        Raises:
+            NotImplementedError: If Alice and Bob measure unequal numbers of Paulis.
+        """
+        # return self._select_choices_from_second_data()
+        if game == "guess_3rd":
+            return self._generate_choices_from_rules_guess_3rd()
+        if game == "measure_3rd_classical_multiplication":
+            return self._generate_choices_from_rules_measure_3rd_classical_multiplication()
+        if game == "measure_3rd_quantum_multiplication":
+            return self._generate_choices_from_rules_measure_3rd_quantum_multiplication()
+
+    def get_win_matrix(self, game, seed: int | None = None) -> np.ndarray:
+        """Find the fraction of the time that
+        Alice and Bob "agree" (in the intersection)
+        given that
+        they "multiply correctly" (alice to -1 and bob to +1).
+
+        Args:
+            seed: The seed for the random number generator.
+            game:
+                guess_3rd means making two measurements and infering the third bit
+                measure_3rd_classical_multiplication: make 4 measurements for Alice and 4 for Bob.
+                get three bits out of them by mutiplying two of them toghether.
+                This corresponds to measure A and B to compute A*B.
+                measure_3rd_quantum_multiplication: make 3 measurements for Alice and 3 for Bob.
+                Use a two qubit interaction to directly measure A*B.
+
+        Returns:
+            The fraction of the time that they "agree" given that they "multiply correctly".
+        """
+        alice_choices, bob_choices = self.generate_choices(game, seed)
+        win_matrix = np.zeros((3, 3))
+        repetitions = alice_choices.shape[2]
+        print(f"{repetitions=}")
+        for row in range(3):
+            for col in range(3):
+                number_of_matches = (
+                    0  # if multiplication rules are not respected, there is no match
+                )
+                for rep in range(repetitions):
+                    alice_triad = alice_choices[row, col, rep, :]
+                    bob_triad = bob_choices[row, col, rep, :]
+                    if np.sum(alice_triad) % 2 == 0 and np.sum(bob_triad) % 2 == 1:
+                        number_of_matches += 1
+                        if alice_triad[col] == bob_triad[row]:
+                            win_matrix[row, col] += 1
+                print("Times they both multi[ly correctly to +-1 =", number_of_matches)
+                win_matrix[row, col] = (
+                    win_matrix[row, col] / number_of_matches
+                )  # TODO: uncomment once done with testing
+        return win_matrix
+
+    def get_multiply_matrix(self, game, seed: int | None = None) -> np.ndarray:
+        """Find the fraction of the time that Alice and Bob
+        "multiply correctly" (alice to -1 and bob to +1).
+
+        Args:
+            seed: The seed for the random number generator.
+            game:
+                guess_3rd means making two measurements and infering the third bit
+                measure_3rd_classical_multiplication: make 4 measurements for Alice and 4 for Bob.
+                get three bits out of them by mutiplying two of them toghether.
+                This corresponds to measure A and B to compute A*B.
+                measure_3rd_quantum_multiplication: make 3 measurements for Alice and 3 for Bob.
+                Use a two qubit interaction to directly measure A*B.
+
+        Returns:
+            The fraction of the time that they "multiply correctly".
+        """
+        alice_choices, bob_choices = self.generate_choices(game, seed)
+        win_matrix = np.zeros((3, 3))
+        repetitions = alice_choices.shape[2]
+        print(f"{repetitions=}")
+        for row in range(3):
+            for col in range(3):
+                for rep in range(repetitions):
+                    alice_triad = alice_choices[row, col, rep, :]
+                    bob_triad = bob_choices[row, col, rep, :]
+                    if np.sum(alice_triad) % 2 == 0 and np.sum(bob_triad) % 2 == 1:
+                        win_matrix[row, col] += 1
+
+                win_matrix[row, col] = win_matrix[row, col] / repetitions
+        return win_matrix
+
+    def get_agree_matrix(self, game, seed: int | None = None) -> np.ndarray:
+        """Find the fraction of the time that Alice and Bob
+        Alice and Bob "agree"(in the intersection) .
+
+        Args:
+            seed: The seed for the random number generator.
+            game:
+                guess_3rd means making two measurements and infering the third bit
+                measure_3rd_classical_multiplication: make 4 measurements for Alice and 4 for Bob.
+                get three bits out of them by mutiplying two of them toghether.
+                This corresponds to measure A and B to compute A*B.
+                measure_3rd_quantum_multiplication: make 3 measurements for Alice and 3 for Bob.
+                Use a two qubit interaction to directly measure A*B.
+
+        Returns:
+            The fraction of the time that they "agree".
+        """
+        alice_choices, bob_choices = self.generate_choices(game, seed)
+        win_matrix = np.zeros((3, 3))
+        repetitions = alice_choices.shape[2]
+        print(f"{repetitions=}")
+        for row in range(3):
+            for col in range(3):
+                for rep in range(repetitions):
+                    alice_triad = alice_choices[row, col, rep, :]
+                    bob_triad = bob_choices[row, col, rep, :]
+                    if alice_triad[col] == bob_triad[row]:
+                        win_matrix[row, col] += 1
+                win_matrix[row, col] = win_matrix[row, col] / repetitions
+        return win_matrix
+
+    def get_agree_and_multiply_matrix(self, game, seed: int | None = None) -> np.ndarray:
+        """Find the fraction of the time that Alice and Bob
+        Alice and Bob "agree" (in the intersection)
+        and
+        they "multiply correctly" (alice to -1 and bob to +1).
+
+        Args:
+            seed: The seed for the random number generator.
+            game:
+                guess_3rd means making two measurements and infering the third bit
+                measure_3rd_classical_multiplication: make 4 measurements for Alice and 4 for Bob.
+                get three bits out of them by mutiplying two of them toghether.
+                This corresponds to measure A and B to compute A*B.
+                measure_3rd_quantum_multiplication: make 3 measurements for Alice and 3 for Bob.
+                Use a two qubit interaction to directly measure A*B.
+
+        Returns:
+            The fraction of the time that they "multiply correctly" AND "agree".
+        """
+        alice_choices, bob_choices = self.generate_choices(game, seed)
+        win_matrix = np.zeros((3, 3))
+        repetitions = alice_choices.shape[2]
+        print(f"{repetitions=}")
+        for row in range(3):
+            for col in range(3):
+                for rep in range(repetitions):
+                    alice_triad = alice_choices[row, col, rep, :]
+                    bob_triad = bob_choices[row, col, rep, :]
+                    if (
+                        alice_triad[col] == bob_triad[row]
+                        and np.sum(alice_triad) % 2 == 0
+                        and np.sum(bob_triad) % 2 == 1
+                    ):
+                        win_matrix[row, col] += 1
+                win_matrix[row, col] = win_matrix[row, col] / repetitions
+        return win_matrix
+
+
+def run_contextuality_experiment(
+    sampler: cirq.Sampler,
+    alice_qubits: list[cirq.GridQubit],
+    bob_qubits: list[cirq.GridQubit],
+    game: Literal[
+        "guess_3rd", "measure_3rd_classical_multiplication", "measure_3rd_quantum_multiplication"
+    ],
+    sub_case: Literal["square_1", "square_2", "only_two_qubits"],
+    repetitions: int = 10_000,
+    add_dd: bool = True,
+    dd_scheme: tuple[cirq.Gate, ...] = (cirq.X, cirq.Y, cirq.X, cirq.Y),
+) -> ContextualityResult:
+    """Run the contextuality warm-up experiment.
+
+    Args:
+        sampler: The hardware sampler or simulator.
+        alice_qubits: Alice's qubits, order is (measure, measure, data, data, measure) or (measure,
+            data, data, measure).
+        bob_qubits: Bob's qubits, (order is measure, measure, data, data, measure) or (measure,
+            data, data, measure).
+        repetitions: The number of repetitions for each row and column of the Mermin-Peres square.
+        add_dd: Whether to add dynamical decoupling.
+        dd_scheme: The dynamical decoupling sequence to use if doing DD.
+        game:
+                guess_3rd means making two measurements and infering the third bit
+                measure_3rd_classical_multiplication: make 4 measurements for Alice and 4 for Bob.
+                get three bits out of them by mutiplying two of them toghether.
+                This corresponds to measure A and B to compute A*B.
+                measure_3rd_quantum_multiplication: make 3 measurements for Alice and 3 for Bob.
+                Use a two qubit interaction to directly measure A*B.
+        sub_case:
+            square1 is the wikipedia square: https://en.wikipedia.org/wiki/Quantum_pseudo-telepathy
+            square2 is not implemented, all blocks have 2body observables
+            only_two_qubits means with 4q total (2 per player). Can only do guess_3rd
+
+    Returns:
+        A ContextualityResult object containing the experiment results.
+    """
+
+    all_circuits = []
+    for mermin_row in range(3):
+        for mermin_col in range(3):
+            all_circuits.append(
+                construct_contextuality_circuit(
+                    alice_qubits,
+                    bob_qubits,
+                    mermin_row,
+                    mermin_col,
+                    add_dd,
+                    game,
+                    sub_case,
+                    dd_scheme,
+                )
+            )
+    results = sampler.run_batch(all_circuits, repetitions=repetitions)
+
+    alice_measurements = np.zeros((3, 3, repetitions, 3), dtype=bool)
+    bob_measurements = np.zeros((3, 3, repetitions, 3), dtype=bool)
+    idx = 0
+
+    # Useful for classical multiplication
+    def multiply_bool(bool_0: list[bool] | Any, bool_1: list[bool] | Any):
+        return [el0 == el1 for el0, el1 in zip(bool_0, bool_1)]
+
+    for row in range(3):
+        for col in range(3):
+            if sub_case == "only_two_qubits":
+                alice_measurements[row, col, :, :2] = results[idx][0].measurements[
+                    "alice_datas"
+                ]
+
+                bob_measurements[row, col, :, :2] = results[idx][0].measurements["bob_datas"]
+            else:
+                alice_measurements[row, col, :, :2] = results[idx][0].measurements["alice"]
+                bob_measurements[row, col, :, :2] = results[idx][0].measurements["bob"]
+
+            if game == "measure_3rd_classical_multiplication":
+                alice_measurements[row, col, :, 2] = multiply_bool(
+                    results[idx][0].measurements["alice_datas"][:, 1],
+                    results[idx][0].measurements["alice_datas"][:, 0],
+                )
+                bob_measurements[row, col, :, 2] = multiply_bool(
+                    results[idx][0].measurements["bob_datas"][:, 1],
+                    results[idx][0].measurements["bob_datas"][:, 0],
+                )
+            if game == "measure_3rd_quantum_multiplication":
+                alice_measurements[row, col, :, 2] = results[idx][0].measurements[
+                    "alice_datas"
+                ][:, 0]
+                bob_measurements[row, col, :, 2] = results[idx][0].measurements["bob_datas"][
+                    :, 0
+                ]
+
+            idx += 1
+
+    return ContextualityResult(alice_measurements, bob_measurements)
+
+
+def bell_pair_prep_circuit(q0: cirq.GridQubit, q1: cirq.GridQubit) -> cirq.Circuit:
+    """Prepare a Bell state between qubits q0 and q1.
+
+    Args:
+        q0: One qubit.
+        q1: The other qubit.
+
+    Returns:
+        A circuit creating a Bell state.
+    """
+    return cirq.Circuit(cirq.H.on_each(q0, q1), cirq.CZ(q0, q1), cirq.H(q1))
+
+
+def state_prep_circuit(
+    alice_data_qubits: tuple[cirq.GridQubit, cirq.GridQubit],
+    bob_data_qubits: tuple[cirq.GridQubit, cirq.GridQubit],
+) -> cirq.Circuit:
+    """Construct a circuit to produce the initial Bell pairs.
+
+    Args:
+        alice_data_qubits: Alice's data qubits.
+        bob_data_qubits: Bob's data qubits.
+
+    Returns:
+        A circuit preparing the Bell states.
+    """
+    pairs = ((alice_data_qubits[0], bob_data_qubits[0]), (alice_data_qubits[1], bob_data_qubits[1]))
+    return bell_pair_prep_circuit(*pairs[0]).zip(bell_pair_prep_circuit(*pairs[1]))
+
+
+def construct_measure_circuit(
+    alice_qubits: list[cirq.GridQubit],
+    bob_qubits: list[cirq.GridQubit],
+    mermin_row: int,
+    mermin_col: int,
+    game: Literal[
+        "guess_3rd", "measure_3rd_classical_multiplication", "measure_3rd_quantum_multiplication"
+    ],
+    sub_case: Literal["square_1", "square_2", "only_two_qubits"],
+) -> cirq.Circuit:
+    """Construct a circuit to implement the measurement.
+
+    We use the conventions described in https://en.wikipedia.org/wiki/Quantum_pseudo-telepathy.
+    In particular, the Mermin-Peres table is
+
+     I ⊗ Z | Z ⊗ I | Z ⊗ Z
+     X ⊗ I | I ⊗ X | X ⊗ X
+    -X ⊗ Z |-Z ⊗ X | Y ⊗ Y
+
+    Args:
+        alice_qubits: The line of qubits to use for Alice (measure, data, data, measure).
+        bob_qubits: The line of qubits to use for Bob (measure, data, data, measure).
+        mermin_row: The row of the Mermin-Peres square to measure.
+        mermin_col: The column of the Mermin-Peres square to measure.
+        game:
+            guess_3rd means making two measurements and infering the third bit
+            measure_3rd_classical_multiplication: make 4 measurements for Alice and 4 for Bob.
+            get three bits out of them by mutiplying two of them toghether.
+            This corresponds to measure A and B to compute A*B.
+            measure_3rd_quantum_multiplication: make 3 measurements for Alice and 3 for Bob.
+            Use a two qubit interaction to directly measure A*B.
+        sub_case:
+            square1 is the wikipedia square: https://en.wikipedia.org/wiki/Quantum_pseudo-telepathy
+            square2 is not implemented, all blocks have 2body observables
+            only_two_qubits means with 4q total (2 per player). Can only do guess_3rd
+
+    Returns:
+        A circuit implementing the measurement.
+    """
+
+    q = alice_qubits[1:3]  # data qubits
+    m = (alice_qubits[0], alice_qubits[3])  # measure qubits
+    if mermin_row == 0:
+        # print("print me ")
+        if sub_case == "square_1":
+            alice_circuit = cirq.Circuit(
+                # map datas into two measures to measure I ⊗ Z  and Z ⊗ I on them
+                cirq.H.on_each(*m),
+                cirq.CZ.on_each(*zip(m, q)),
+                cirq.H.on_each(*m),
+                # map the two datas onto the second data
+                cirq.Moment(cirq.M(*m, key="alice")),
+            )
+
+            if game == "guess_3rd":
+                pass
+            elif game == "measure_3rd_classical_multiplication":
+                alice_circuit.append(cirq.M(*q, key="alice_datas"))
+
+            elif game == "measure_3rd_quantum_multiplication":
+                alice_circuit.append([
+                    cirq.H.on(q[1]),
+                    cirq.CZ.on(*q),
+                    cirq.H.on(q[1]),
+                    cirq.M(q[1], key="alice_datas"),
+                ])
+
+        if sub_case == "only_two_qubits":
+            alice_circuit = cirq.Circuit(cirq.Moment(cirq.M(*q, key="alice_datas")))
+
+            if game == "guess_3rd":
+                pass
+            else:
+                raise ValueError("You can only game = guess_3rd if you sub_case = only_two_qubits")
+
+    elif mermin_row == 1:
+        if sub_case == "square_1":
+            alice_circuit = cirq.Circuit(
+                cirq.H.on_each(*q, *m),
+                cirq.CZ.on_each(*zip(q, m)),
+                cirq.H.on_each(*m),
+                cirq.Moment(cirq.M(*m, key="alice")),
+            )
+
+            if game == "guess_3rd":
+                pass
+
+            elif game == "measure_3rd_classical_multiplication":
+                alice_circuit.append(cirq.M(*q, key="alice_datas"))
+
+            elif game == "measure_3rd_quantum_multiplication":
+                alice_circuit.append([
+                    cirq.H.on(q[1]),
+                    cirq.CZ.on(*q),
+                    cirq.H.on(q[1]),
+                    cirq.M(q[1], key="alice_datas"),
+                ])
+
+        if sub_case == "only_two_qubits":
+            alice_circuit = cirq.Circuit(
+                cirq.Moment(cirq.H.on_each(*q)), cirq.Moment(cirq.M(*q, key="alice_datas"))
+            )
+
+            if game == "guess_3rd":
+                pass
+            else:
+                raise ValueError("You can only game = guess_3rd if you sub_case = only_two_qubits")
+
+    elif mermin_row == 2:
+        if sub_case == "square_1":
+            alice_circuit = cirq.Circuit(
+                cirq.CZ(*q),
+                cirq.Moment(cirq.H.on_each(*q, *m)),
+                cirq.CZ.on_each(*zip(m, q)),
+                cirq.H.on_each(*m),
+                cirq.Moment(cirq.H.on_each(*q)),
+                cirq.CZ(*q),
+                cirq.Moment(cirq.M(*m, key="alice")),
+            )
+
+            if game == "guess_3rd":
+                pass
+            elif game == "measure_3rd_classical_multiplication":
+                alice_circuit.append([
+                    cirq.Rx(rads=np.pi / 2).on_each(*q),
+                    cirq.M(*q, key="alice_datas"),
+                ])
+
+
+            elif game == "measure_3rd_quantum_multiplication":
+                alice_circuit.append([
+                    cirq.Rx(rads=np.pi / 2).on_each(*q),
+                    cirq.H.on(q[1]),
+                    cirq.CZ.on(*q),
+                    cirq.H.on(q[1]),
+                    cirq.M(q[1], key="alice_datas"),
+                ])
+
+
+        if sub_case == "only_two_qubits":
+            alice_circuit = cirq.Circuit(
+                cirq.ry(np.pi / 2)(q[0]),
+                cirq.H.on(q[0]),
+                cirq.CZ.on(*q),
+                cirq.Moment(cirq.H.on_each(*q)),
+                cirq.X.on(q[0]),
+                cirq.Moment(cirq.M(*q, key="alice_datas")),
+            )
+
+            if game == "guess_3rd":
+                pass
+            else:
+                raise ValueError("You can only game = guess_3rd if you sub_case = only_two_qubits")
+
+    q = bob_qubits[1:3]  # data qubits
+    m = (bob_qubits[0], bob_qubits[3])  # measure qubits
+    if mermin_col == 0:
+        if sub_case == "square_1":
+            bob_circuit = cirq.Circuit(
+                # map datas onto measures to measure I ⊗ Z and X ⊗ I on them
+                cirq.H.on_each(*m, q[0]),
+                cirq.CZ.on_each(*zip(m, q)),
+                cirq.H.on_each(*m),
+                cirq.Moment(cirq.M(*m, key="bob")),
+            )
+
+            if game == "guess_3rd":
+                pass
+            elif game == "measure_3rd_classical_multiplication":
+                bob_circuit.append(cirq.M(*q, key="bob_datas"))
+
+
+            elif game == "measure_3rd_quantum_multiplication":
+                bob_circuit.append([
+                    cirq.H.on(q[1]),
+                    cirq.CZ.on(*q),
+                    cirq.H.on(q[1]),
+                    cirq.M(q[1], key="bob_datas"),
+                ])
+
+        if sub_case == "only_two_qubits":
+            bob_circuit = cirq.Circuit(cirq.H.on(q[0]), cirq.Moment(cirq.M(*q, key="bob_datas")))
+
+            if game == "guess_3rd":
+                pass
+            else:
+                raise ValueError("You can only game = guess_3rd if you sub_case = only_two_qubits")
+
+    elif mermin_col == 1:
+        if sub_case == "square_1":
+            bob_circuit = cirq.Circuit(
+                # map datas onto measures to measure Z ⊗ I and I ⊗ X on them
+                cirq.H.on_each(*m, q[1]),
+                cirq.CZ.on_each(*zip(m, q)),
+                cirq.H.on_each(*m),
+                cirq.Moment(cirq.M(*m, key="bob")),
+            )
+
+            if game == "guess_3rd":
+                pass
+            elif game == "measure_3rd_classical_multiplication":
+                bob_circuit.append(cirq.M(*q, key="bob_datas"))
+
+            elif game == "measure_3rd_quantum_multiplication":
+                bob_circuit.append([
+                    cirq.H.on(q[1]),
+                    cirq.CZ.on(*q),
+                    cirq.H.on(q[1]),
+                    cirq.M(q[1], key="bob_datas"),
+                ])
+
+
+        if sub_case == "only_two_qubits":
+            bob_circuit = cirq.Circuit(cirq.H.on(q[1]), cirq.Moment(cirq.M(*q, key="bob_datas")))
+
+            if game == "guess_3rd":
+                pass
+            else:
+                raise ValueError("You can only game = guess_3rd if you sub_case = only_two_qubits")
+
+    elif mermin_col == 2:
+        if sub_case == "square_1":
+            bob_circuit = cirq.Circuit(
+                cirq.H(q[0]),
+                cirq.CZ(*q),
+                cirq.Moment(cirq.H.on_each(*q, *m)),
+                cirq.CZ.on_each(*zip(m, q)),
+                cirq.H.on_each(*m),
+                # re-add Eliott's dropped to circuit
+                cirq.Moment(cirq.H.on_each(*q)),
+                cirq.CZ(*q),
+                cirq.H(q[0]),
+                cirq.Moment(cirq.M(*m, key="bob")),
+            )
+
+            if game == "guess_3rd":
+                pass
+            elif game == "measure_3rd_classical_multiplication":
+                bob_circuit.append([
+                    cirq.Rx(rads=np.pi / 2).on_each(*q),
+                    cirq.M(*q, key="bob_datas"),
+                ])
+
+            elif game == "measure_3rd_quantum_multiplication":
+                bob_circuit.append([
+                    cirq.Rx(rads=np.pi / 2).on_each(*q),
+                    cirq.H.on(q[1]),
+                    cirq.CZ.on(*q),
+                    cirq.H.on(q[1]),
+                    cirq.M(q[1], key="bob_datas"),
+                ])
+
+
+
+        if sub_case == "only_two_qubits":
+            bob_circuit = cirq.Circuit(
+                cirq.H.on(q[0]),
+                cirq.CZ.on(*q),
+                cirq.H.on_each(*q),
+                cirq.Moment(cirq.M(*q, key="bob_datas")),
+            )
+
+
+
+            if game == "guess_3rd":
+                pass
+            else:
+                raise ValueError("You can only sub_case = only_two_qubits if game = guess_3rd")
+    return cirq.align_right(alice_circuit + bob_circuit)
+
+def construct_contextuality_circuit(
+    alice_qubits: list[cirq.GridQubit],
+    bob_qubits: list[cirq.GridQubit],
+    mermin_row: int,
+    mermin_col: int,
+    add_dd: bool,
+    game: Literal[
+        "guess_3rd", "measure_3rd_classical_multiplication", "measure_3rd_quantum_multiplication"
+    ],
+    sub_case: Literal["square_1", "square_2", "only_two_qubits"],
+    dd_scheme: tuple[cirq.Gate, ...] = (cirq.X, cirq.Y, cirq.X, cirq.Y),
+) -> cirq.Circuit:
+    """Construct a circuit to implement the contextuality experiment on hardware.
+
+    We use the conventions described in https://en.wikipedia.org/wiki/Quantum_pseudo-telepathy.
+    In particular, the Mermin-Peres table is
+
+     I ⊗ Z | Z ⊗ I | Z ⊗ Z
+     X ⊗ I | I ⊗ X | X ⊗ X
+    -X ⊗ Z |-Z ⊗ X | Y ⊗ Y
+
+    Args:
+        alice_qubits: The line of qubits to use for Alice (measure, data, data, measure).
+        bob_qubits: The line of qubits to use for Bob (measure, data, data, measure).
+        mermin_row: The row of the Mermin-Peres square to measure.
+        mermin_col: The column of the Mermin-Peres square to measure.
+        add_dd: Whether to add dynamical decoupling.
+        dd_scheme: The dynamical decoupling sequence to use if doing DD.
+        game:
+            guess_3rd means making two measurements and infering the third bit
+            measure_3rd_classical_multiplication: make 4 measurements for Alice and 4 for Bob.
+            get three bits out of them by mutiplying two of them toghether.
+            This corresponds to measure A and B to compute A*B.
+            measure_3rd_quantum_multiplication: make 3 measurements for Alice and 3 for Bob.
+            Use a two qubit interaction to directly measure A*B.
+
+    Returns:
+        A circuit implementing the game.
+    """
+    alice_data_qubits = (alice_qubits[1], alice_qubits[2])
+    bob_data_qubits = (bob_qubits[1], bob_qubits[2])
+    prep_circuit = state_prep_circuit(alice_data_qubits, bob_data_qubits)  # test cirq.Circuit() #
+    measure_circuit = construct_measure_circuit(
+        alice_qubits, bob_qubits, mermin_row, mermin_col, game, sub_case
+    )
+    circuit = prep_circuit + measure_circuit
+    if add_dd:
+        circuit = cirq.add_dynamical_decoupling(
+            circuit, single_qubit_gate_moments_only=True, schema=dd_scheme
+        )
+    return circuit

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -713,7 +713,7 @@ def construct_contextuality_circuit(
         add_dd: Whether to add dynamical decoupling.
         dd_scheme: The dynamical decoupling sequence to use if doing DD.
         game:
-            "infer_3rd": making two measurements and inferring the third bit
+            "infer_3rd": make two measurements and infer the third bit.
             "measure_3rd_classical_multiplication": make 4 measurements for Alice and 4 for Bob.
             get three bits out of them by multiplying two of them together.
             This corresponds to measure A and B to compute A*B.

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -55,8 +55,25 @@ class ContextualityResult:
     alice_measurements: np.ndarray
     bob_measurements: np.ndarray
 
-    def _select_choices_from_second_data(self) -> tuple[np.ndarray, np.ndarray]:
-        return self.alice_measurements, self.bob_measurements
+    def _assign_choices_from_measurements(self) -> tuple[np.ndarray, np.ndarray]:
+        """Initialize and assign choices from Alice and Bob's measurements."""
+
+        repetitions = self.alice_measurements.shape[2]
+
+        # the following two arrays have indices signifying
+        # [query_row, query_column, repetition, index_of_output]
+        alice_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
+        bob_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
+
+        alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1]  # I ⊗ Z
+        alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]  # Z ⊗ I
+        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]  # X ⊗ I | I ⊗ X
+        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]  # -X ⊗ Z |-Z ⊗ X
+        bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1]  # I ⊗ Z
+        bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0]  # X ⊗ I
+        bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2]  # Z ⊗ I | I ⊗ X
+
+        return alice_choices, bob_choices
 
     def _generate_choices_from_rules_infer_3rd(self) -> tuple[np.ndarray, np.ndarray]:
         """Generate choices from Alice and Bob's measurements by inferring the third number from the
@@ -65,22 +82,7 @@ class ContextualityResult:
         Returns:
             Alice and Bob's choices in the game.
         """
-        repetitions = self.alice_measurements.shape[2]
-
-        # the following two arrays have indices signifying
-        # [query_row, query_column, repetition, index_of_output]
-        alice_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
-        bob_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
-
-        # the following manipulations implment the Mermin-Peres square from the
-        # docstring of `construct_contextuality_circuit`
-        alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1]  # I ⊗ Z
-        alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]  # Z ⊗ I
-        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]  # X ⊗ I | I ⊗ X
-        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]  # -X ⊗ Z |-Z ⊗ X
-        bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1]  # I ⊗ Z
-        bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0]  # X ⊗ I
-        bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2]  # Z ⊗ I | I ⊗ X
+        alice_choices, bob_choices = self._assign_choices_from_measurements()
 
         alice_choices[:, :, :, 2] = np.sum(alice_choices, axis=3) % 2  # infer from rule
         bob_choices[:, :, :, 2] = 1 - (np.sum(bob_choices, axis=3) % 2)  # infer from rule
@@ -95,20 +97,7 @@ class ContextualityResult:
         Returns:
             Alice and Bob's choices in the game.
         """
-        repetitions = self.alice_measurements.shape[2]
-
-        # the following two arrays have indices signifying
-        # [query_row, query_column, repetition, index_of_output]
-        alice_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
-        bob_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
-
-        alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1]  # I ⊗ Z
-        alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]  # Z ⊗ I
-        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]  # X ⊗ I | I ⊗ X
-        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]  # -X ⊗ Z |-Z ⊗ X
-        bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1]  # I ⊗ Z
-        bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0]  # X ⊗ I
-        bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2]  # Z ⊗ I | I ⊗ X
+        alice_choices, bob_choices = self._assign_choices_from_measurements()
 
         alice_choices[:, :, :, 2] = 1 - self.alice_measurements[:, :, :, 2]
 
@@ -131,20 +120,7 @@ class ContextualityResult:
         Returns:
             Alice and Bob's choices in the game.
         """
-        repetitions = self.alice_measurements.shape[2]
-
-        # the following two arrays have indices signifying
-        # [query_row, query_column, repetition, index_of_output]
-        alice_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
-        bob_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
-
-        alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1]  # I ⊗ Z
-        alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]  # Z ⊗ I
-        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]  # X ⊗ I | I ⊗ X
-        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]  # -X ⊗ Z |-Z ⊗ X
-        bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1]  # I ⊗ Z
-        bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0]  # X ⊗ I
-        bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2]  # Z ⊗ I | I ⊗ X
+        alice_choices, bob_choices = self._assign_choices_from_measurements()
 
         alice_choices[:, :, :, 2] = self.alice_measurements[:, :, :, 2]
         bob_choices[:, 0, :, 2] = 1 - self.bob_measurements[:, 0, :, 2]
@@ -175,7 +151,6 @@ class ContextualityResult:
         Raises:
             NotImplementedError: If Alice and Bob measure unequal numbers of Paulis.
         """
-        # return self._select_choices_from_second_data()
         if game == "infer_3rd":
             return self._generate_choices_from_rules_infer_3rd()
         if game == "measure_3rd_classical_multiplication":

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -384,7 +384,7 @@ def run_contextuality_experiment(
     return ContextualityResult(alice_measurements, bob_measurements)
 
 
-def multiply_bool(bool_0: list[bool], bool_1: list[bool]) -> list[bool]:
+def multiply_bool(bool_0: np.ndarray, bool_1: np.ndarray) -> np.ndarray:
     """Perform boolean multiplication. Useful for "measure_3rd_classical_multiplication"."""
     return bool_0 == bool_1
 

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -145,8 +145,8 @@ class ContextualityResult:
                 Use a two qubit interaction to directly measure A*B.
 
         Returns:
-            Alice and Bob's choices in the game. The two numpy arrays have indices
-            signifying [query_row, query_column, repetition, index_of_output].
+            Alice and Bob's choices in the game. The two numpy arrays have indices signifying
+                [query_row, query_column, repetition, index_of_output].
 
         Raises:
             NotImplementedError: If Alice and Bob measure unequal numbers of Paulis.

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -158,7 +158,7 @@ class ContextualityResult:
         if game == "measure_3rd_quantum_multiplication":
             return self._generate_choices_from_rules_measure_3rd_quantum_multiplication()
 
-    def get_win_matrix(self, game: GameType) -> np.ndarray:
+    def get_agree_given_multiply_matrix(self, game: GameType) -> np.ndarray:
         """Find the fraction of the time that Alice and Bob "agree" (in the intersection) given that
         they "multiply correctly" (alice to -1 and bob to +1).
 
@@ -175,7 +175,7 @@ class ContextualityResult:
             The fraction of the time that they "agree" given that they "multiply correctly".
         """
         alice_choices, bob_choices = self.generate_choices(game)
-        win_matrix = np.zeros((3, 3))
+        agree_given_multiply_matrix = np.zeros((3, 3))
         repetitions = alice_choices.shape[2]
         print(f"{repetitions=}")
         for row in range(3):
@@ -188,12 +188,12 @@ class ContextualityResult:
                     if np.sum(alice_triad) % 2 == 0 and np.sum(bob_triad) % 2 == 1:
                         number_of_matches += 1
                         if alice_triad[col] == bob_triad[row]:
-                            win_matrix[row, col] += 1
+                            agree_given_multiply_matrix[row, col] += 1
                 print("Times they both multiply correctly to +-1 =", number_of_matches)
-                win_matrix[row, col] = (
-                    win_matrix[row, col] / number_of_matches
+                agree_given_multiply_matrix[row, col] = (
+                    agree_given_multiply_matrix[row, col] / number_of_matches
                 )
-        return win_matrix
+        return agree_given_multiply_matrix
 
     def get_multiply_matrix(self, game: GameType) -> np.ndarray:
         """Find the fraction of the time that Alice and Bob
@@ -212,7 +212,7 @@ class ContextualityResult:
             The fraction of the time that they "multiply correctly".
         """
         alice_choices, bob_choices = self.generate_choices(game)
-        win_matrix = np.zeros((3, 3))
+        multiply_matrix = np.zeros((3, 3))
         repetitions = alice_choices.shape[2]
         print(f"{repetitions=}")
         for row in range(3):
@@ -221,10 +221,10 @@ class ContextualityResult:
                     alice_triad = alice_choices[row, col, rep, :]
                     bob_triad = bob_choices[row, col, rep, :]
                     if np.sum(alice_triad) % 2 == 0 and np.sum(bob_triad) % 2 == 1:
-                        win_matrix[row, col] += 1
+                        multiply_matrix[row, col] += 1
 
-                win_matrix[row, col] = win_matrix[row, col] / repetitions
-        return win_matrix
+                multiply_matrix[row, col] = multiply_matrix[row, col] / repetitions
+        return multiply_matrix
 
     def get_agree_matrix(self, game: GameType) -> np.ndarray:
         """Fraction of the time that Alice and Bob Alice and Bob "agree" (in the intersection).
@@ -242,7 +242,7 @@ class ContextualityResult:
             The fraction of the time that they "agree".
         """
         alice_choices, bob_choices = self.generate_choices(game)
-        win_matrix = np.zeros((3, 3))
+        agree_matrix = np.zeros((3, 3))
         repetitions = alice_choices.shape[2]
         print(f"{repetitions=}")
         for row in range(3):
@@ -251,9 +251,9 @@ class ContextualityResult:
                     alice_triad = alice_choices[row, col, rep, :]
                     bob_triad = bob_choices[row, col, rep, :]
                     if alice_triad[col] == bob_triad[row]:
-                        win_matrix[row, col] += 1
-                win_matrix[row, col] = win_matrix[row, col] / repetitions
-        return win_matrix
+                        agree_matrix[row, col] += 1
+                agree_matrix[row, col] = agree_matrix[row, col] / repetitions
+        return agree_matrix
 
     def get_agree_and_multiply_matrix(self, game: GameType) -> np.ndarray:
         """Find the fraction of the time that Alice and Bob
@@ -274,7 +274,7 @@ class ContextualityResult:
             The fraction of the time that they "multiply correctly" AND "agree".
         """
         alice_choices, bob_choices = self.generate_choices(game)
-        win_matrix = np.zeros((3, 3))
+        agree_and_multiply_matrix = np.zeros((3, 3))
         repetitions = alice_choices.shape[2]
         print(f"{repetitions=}")
         for row in range(3):
@@ -287,9 +287,9 @@ class ContextualityResult:
                         and np.sum(alice_triad) % 2 == 0
                         and np.sum(bob_triad) % 2 == 1
                     ):
-                        win_matrix[row, col] += 1
-                win_matrix[row, col] = win_matrix[row, col] / repetitions
-        return win_matrix
+                        agree_and_multiply_matrix[row, col] += 1
+                agree_and_multiply_matrix[row, col] = agree_and_multiply_matrix[row, col] / repetitions
+        return agree_and_multiply_matrix
 
 
 def run_contextuality_experiment(

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -32,13 +32,13 @@ from typing import Any, Literal
 import cirq
 import numpy as np
 
-type GameType = Literal[
+GameType = Literal[
     "infer_3rd",
     "measure_3rd_classical_multiplication",
     "measure_3rd_quantum_multiplication",
 ]
 
-type SubCase = Literal["square_1", "square_2", "only_two_qubits"]
+SubCase = Literal["square_1", "square_2", "only_two_qubits"]
 
 
 @dataclasses.dataclass

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -386,7 +386,7 @@ def run_contextuality_experiment(
 
 def multiply_bool(bool_0: list[bool], bool_1: list[bool]) -> list[bool]:
     """Perform boolean multiplication. Useful for "measure_3rd_classical_multiplication"."""
-    return [el0 == el1 for el0, el1 in zip(bool_0, bool_1)]
+    return bool_0 == bool_1
 
 
 def bell_pair_prep_circuit(q0: cirq.GridQubit, q1: cirq.GridQubit) -> cirq.Circuit:

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -33,7 +33,7 @@ import cirq
 import numpy as np
 
 type GameType = Literal[
-    "guess_3rd",
+    "infer_3rd",
     "measure_3rd_classical_multiplication",
     "measure_3rd_quantum_multiplication",
 ]
@@ -58,7 +58,7 @@ class ContextualityResult:
     def _select_choices_from_second_data(self) -> tuple[np.ndarray, np.ndarray]:
         return self.alice_measurements, self.bob_measurements
 
-    def _generate_choices_from_rules_guess_3rd(self) -> tuple[np.ndarray, np.ndarray]:
+    def _generate_choices_from_rules_infer_3rd(self) -> tuple[np.ndarray, np.ndarray]:
         """Generate choices from Alice and Bob's measurements by inferring the third number from the
         first two.
 
@@ -161,9 +161,9 @@ class ContextualityResult:
 
         Args:
             game:
-                guess_3rd means making two measurements and infering the third bit
+                infer_3rd means making two measurements and inferring the third bit
                 "measure_3rd_classical_multiplication": make 4 measurements for Alice and 4 for Bob.
-                get three bits out of them by mutiplying two of them toghether.
+                get three bits out of them by multiplying two of them together.
                 This corresponds to measure A and B to compute A*B.
                 "measure_3rd_quantum_multiplication": make 3 measurements for Alice and 3 for Bob.
                 Use a two qubit interaction to directly measure A*B.
@@ -176,8 +176,8 @@ class ContextualityResult:
             NotImplementedError: If Alice and Bob measure unequal numbers of Paulis.
         """
         # return self._select_choices_from_second_data()
-        if game == "guess_3rd":
-            return self._generate_choices_from_rules_guess_3rd()
+        if game == "infer_3rd":
+            return self._generate_choices_from_rules_infer_3rd()
         if game == "measure_3rd_classical_multiplication":
             return self._generate_choices_from_rules_measure_3rd_classical_multiplication()
         if game == "measure_3rd_quantum_multiplication":
@@ -189,9 +189,9 @@ class ContextualityResult:
 
         Args:
             game:
-                guess_3rd means making two measurements and infering the third bit
+                infer_3rd means making two measurements and inferring the third bit
                 "measure_3rd_classical_multiplication": make 4 measurements for Alice and 4 for Bob.
-                get three bits out of them by mutiplying two of them toghether.
+                get three bits out of them by multiplying two of them together.
                 This corresponds to measure A and B to compute A*B.
                 "measure_3rd_quantum_multiplication": make 3 measurements for Alice and 3 for Bob.
                 Use a two qubit interaction to directly measure A*B.
@@ -226,9 +226,9 @@ class ContextualityResult:
 
         Args:
             game:
-                guess_3rd means making two measurements and infering the third bit
+                infer_3rd means making two measurements and inferring the third bit
                 "measure_3rd_classical_multiplication": make 4 measurements for Alice and 4 for Bob.
-                get three bits out of them by mutiplying two of them toghether.
+                get three bits out of them by multiplying two of them together.
                 This corresponds to measure A and B to compute A*B.
                 "measure_3rd_quantum_multiplication": make 3 measurements for Alice and 3 for Bob.
                 Use a two qubit interaction to directly measure A*B.
@@ -256,9 +256,9 @@ class ContextualityResult:
 
         Args:
             game:
-                "guess_3rd": making two measurements and infering the third bit
+                "infer_3rd": making two measurements and inferring the third bit
                 "measure_3rd_classical_multiplication": make 4 measurements for Alice and 4 for Bob.
-                get three bits out of them by mutiplying two of them toghether.
+                get three bits out of them by multiplying two of them together.
                 This corresponds to measure A and B to compute A*B.
                 "measure_3rd_quantum_multiplication": make 3 measurements for Alice and 3 for Bob.
                 Use a two qubit interaction to directly measure A*B.
@@ -288,9 +288,9 @@ class ContextualityResult:
 
         Args:
             game:
-                "guess_3rd": making two measurements and infering the third bit
+                "infer_3rd": making two measurements and inferring the third bit
                 "measure_3rd_classical_multiplication": make 4 measurements for Alice and 4 for Bob.
-                get three bits out of them by mutiplying two of them toghether.
+                get three bits out of them by multiplying two of them together.
                 This corresponds to measure A and B to compute A*B.
                 "measure_3rd_quantum_multiplication": make 3 measurements for Alice and 3 for Bob.
                 Use a two qubit interaction to directly measure A*B.
@@ -339,16 +339,16 @@ def run_contextuality_experiment(
         add_dd: Whether to add dynamical decoupling.
         dd_scheme: The dynamical decoupling sequence to use if doing DD.
         game:
-                "guess_3rd": making two measurements and infering the third bit
+                "infer_3rd": making two measurements and inferring the third bit
                 "measure_3rd_classical_multiplication": make 4 measurements for Alice and 4 for Bob.
-                get three bits out of them by mutiplying two of them toghether.
+                get three bits out of them by multiplying two of them together.
                 This corresponds to measure A and B to compute A*B.
                 "measure_3rd_quantum_multiplication": make 3 measurements for Alice and 3 for Bob.
                 Use a two qubit interaction to directly measure A*B.
         sub_case:
             square1 is the wikipedia square: https://en.wikipedia.org/wiki/Quantum_pseudo-telepathy
             square2 is not implemented, all blocks have 2body observables
-            only_two_qubits means with 4q total (2 per player). Can only do guess_3rd
+            only_two_qubits means with 4q total (2 per player). Can only do infer_3rd
 
     Returns:
         A ContextualityResult object containing the experiment results.
@@ -467,16 +467,16 @@ def construct_measure_circuit(
         mermin_row: The row of the Mermin-Peres square to measure.
         mermin_col: The column of the Mermin-Peres square to measure.
         game:
-            "guess_3rd": making two measurements and infering the third bit
+            "infer_3rd": making two measurements and inferring the third bit
             "measure_3rd_classical_multiplication": make 4 measurements for Alice and 4 for Bob.
-            get three bits out of them by mutiplying two of them toghether.
+            get three bits out of them by multiplying two of them together.
             This corresponds to measure A and B to compute A*B.
             "measure_3rd_quantum_multiplication": make 3 measurements for Alice and 3 for Bob.
             Use a two qubit interaction to directly measure A*B.
         sub_case:
             square1 is the wikipedia square: https://en.wikipedia.org/wiki/Quantum_pseudo-telepathy
             square2 is not implemented, all blocks have 2body observables
-            only_two_qubits means with 4q total (2 per player). Can only do guess_3rd
+            only_two_qubits means with 4q total (2 per player). Can only do infer_3rd
 
     Returns:
         A circuit implementing the measurement.
@@ -495,7 +495,7 @@ def construct_measure_circuit(
                 cirq.Moment(cirq.M(*m, key="alice")),
             )
 
-            if game == "guess_3rd":
+            if game == "infer_3rd":
                 pass
             elif game == "measure_3rd_classical_multiplication":
                 alice_circuit.append(cirq.M(*q, key="alice_datas"))
@@ -511,10 +511,10 @@ def construct_measure_circuit(
         if sub_case == "only_two_qubits":
             alice_circuit = cirq.Circuit(cirq.Moment(cirq.M(*q, key="alice_datas")))
 
-            if game == "guess_3rd":
+            if game == "infer_3rd":
                 pass
             else:
-                raise ValueError("You can only game = guess_3rd if you sub_case = only_two_qubits")
+                raise ValueError("You can only game = infer_3rd if you sub_case = only_two_qubits")
 
     elif mermin_row == 1:
         if sub_case == "square_1":
@@ -525,7 +525,7 @@ def construct_measure_circuit(
                 cirq.Moment(cirq.M(*m, key="alice")),
             )
 
-            if game == "guess_3rd":
+            if game == "infer_3rd":
                 pass
 
             elif game == "measure_3rd_classical_multiplication":
@@ -544,10 +544,10 @@ def construct_measure_circuit(
                 cirq.Moment(cirq.H.on_each(*q)), cirq.Moment(cirq.M(*q, key="alice_datas"))
             )
 
-            if game == "guess_3rd":
+            if game == "infer_3rd":
                 pass
             else:
-                raise ValueError("You can only game = guess_3rd if you sub_case = only_two_qubits")
+                raise ValueError("You can only game = infer_3rd if you sub_case = only_two_qubits")
 
     elif mermin_row == 2:
         if sub_case == "square_1":
@@ -561,7 +561,7 @@ def construct_measure_circuit(
                 cirq.Moment(cirq.M(*m, key="alice")),
             )
 
-            if game == "guess_3rd":
+            if game == "infer_3rd":
                 pass
             elif game == "measure_3rd_classical_multiplication":
                 alice_circuit.append([
@@ -590,10 +590,10 @@ def construct_measure_circuit(
                 cirq.Moment(cirq.M(*q, key="alice_datas")),
             )
 
-            if game == "guess_3rd":
+            if game == "infer_3rd":
                 pass
             else:
-                raise ValueError("You can only game = guess_3rd if you sub_case = only_two_qubits")
+                raise ValueError("You can only game = infer_3rd if you sub_case = only_two_qubits")
 
     q = bob_qubits[1:3]  # data qubits
     m = (bob_qubits[0], bob_qubits[3])  # measure qubits
@@ -607,7 +607,7 @@ def construct_measure_circuit(
                 cirq.Moment(cirq.M(*m, key="bob")),
             )
 
-            if game == "guess_3rd":
+            if game == "infer_3rd":
                 pass
             elif game == "measure_3rd_classical_multiplication":
                 bob_circuit.append(cirq.M(*q, key="bob_datas"))
@@ -624,10 +624,10 @@ def construct_measure_circuit(
         if sub_case == "only_two_qubits":
             bob_circuit = cirq.Circuit(cirq.H.on(q[0]), cirq.Moment(cirq.M(*q, key="bob_datas")))
 
-            if game == "guess_3rd":
+            if game == "infer_3rd":
                 pass
             else:
-                raise ValueError("You can only game = guess_3rd if you sub_case = only_two_qubits")
+                raise ValueError("You can only game = infer_3rd if you sub_case = only_two_qubits")
 
     elif mermin_col == 1:
         if sub_case == "square_1":
@@ -639,7 +639,7 @@ def construct_measure_circuit(
                 cirq.Moment(cirq.M(*m, key="bob")),
             )
 
-            if game == "guess_3rd":
+            if game == "infer_3rd":
                 pass
             elif game == "measure_3rd_classical_multiplication":
                 bob_circuit.append(cirq.M(*q, key="bob_datas"))
@@ -656,10 +656,10 @@ def construct_measure_circuit(
         if sub_case == "only_two_qubits":
             bob_circuit = cirq.Circuit(cirq.H.on(q[1]), cirq.Moment(cirq.M(*q, key="bob_datas")))
 
-            if game == "guess_3rd":
+            if game == "infer_3rd":
                 pass
             else:
-                raise ValueError("You can only game = guess_3rd if you sub_case = only_two_qubits")
+                raise ValueError("You can only game = infer_3rd if you sub_case = only_two_qubits")
 
     elif mermin_col == 2:
         if sub_case == "square_1":
@@ -676,7 +676,7 @@ def construct_measure_circuit(
                 cirq.Moment(cirq.M(*m, key="bob")),
             )
 
-            if game == "guess_3rd":
+            if game == "infer_3rd":
                 pass
             elif game == "measure_3rd_classical_multiplication":
                 bob_circuit.append([
@@ -705,10 +705,10 @@ def construct_measure_circuit(
 
 
 
-            if game == "guess_3rd":
+            if game == "infer_3rd":
                 pass
             else:
-                raise ValueError("You can only sub_case = only_two_qubits if game = guess_3rd")
+                raise ValueError("You can only sub_case = only_two_qubits if game = infer_3rd")
     return cirq.align_right(alice_circuit + bob_circuit)
 
 def construct_contextuality_circuit(
@@ -738,9 +738,9 @@ def construct_contextuality_circuit(
         add_dd: Whether to add dynamical decoupling.
         dd_scheme: The dynamical decoupling sequence to use if doing DD.
         game:
-            "guess_3rd": making two measurements and infering the third bit
+            "infer_3rd": making two measurements and inferring the third bit
             "measure_3rd_classical_multiplication": make 4 measurements for Alice and 4 for Bob.
-            get three bits out of them by mutiplying two of them toghether.
+            get three bits out of them by multiplying two of them together.
             This corresponds to measure A and B to compute A*B.
             "measure_3rd_quantum_multiplication": make 3 measurements for Alice and 3 for Bob.
             Use a two qubit interaction to directly measure A*B.

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -64,19 +64,24 @@ class ContextualityResult:
             Alice and Bob's choices in the game.
         """
         repetitions = self.alice_measurements.shape[2]
+
+        # the following two arrays have indices signifying
+        # [query_row, query_column, repetition, index_of_output]
         alice_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
         bob_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
 
-        alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1]
-        alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]
-        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]
-        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]
-        bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1]
-        bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0]
-        bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2]
+        # the following manipulations implment the Mermin-Peres square from the
+        # docstring of `construct_contextuality_circuit`
+        alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1] # I ⊗ Z
+        alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0] # Z ⊗ I
+        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2] # X ⊗ I | I ⊗ X
+        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2] # -X ⊗ Z |-Z ⊗ X
+        bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1] # I ⊗ Z
+        bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0] # X ⊗ I
+        bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2] # Z ⊗ I | I ⊗ X
 
-        alice_choices[:, :, :, 2] = np.sum(alice_choices, axis=3) % 2
-        bob_choices[:, :, :, 2] = 1 - (np.sum(bob_choices, axis=3) % 2)
+        alice_choices[:, :, :, 2] = np.sum(alice_choices, axis=3) % 2 # infer from rule
+        bob_choices[:, :, :, 2] = 1 - (np.sum(bob_choices, axis=3) % 2) # infer from rule
         return alice_choices, bob_choices
 
     def _generate_choices_from_rules_measure_3rd_classical_multiplication(
@@ -156,7 +161,8 @@ class ContextualityResult:
                 Use a two qubit interaction to directly measure A*B.
 
         Returns:
-            Alice and Bob's choices in the game.
+            Alice and Bob's choices in the game. The two numpy arrays have indices
+            signifying [query_row, query_column, repetition, index_of_output].
 
         Raises:
             NotImplementedError: If Alice and Bob measure unequal numbers of Paulis.

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -263,7 +263,7 @@ class ContextualityResult:
 
         Args:
             game:
-                "infer_3rd": making two measurements and inferring the third bit
+                "infer_3rd": make two measurements and infer the third bit.
                 "measure_3rd_classical_multiplication": make 4 measurements for Alice and 4 for Bob.
                 get three bits out of them by multiplying two of them together.
                 This corresponds to measure A and B to compute A*B.

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -314,7 +314,7 @@ def run_contextuality_experiment(
         add_dd: Whether to add dynamical decoupling.
         dd_scheme: The dynamical decoupling sequence to use if doing DD.
         game:
-                "infer_3rd": making two measurements and inferring the third bit
+                "infer_3rd": make two measurements and infer the third bit.
                 "measure_3rd_classical_multiplication": make 4 measurements for Alice and 4 for Bob.
                 get three bits out of them by multiplying two of them together.
                 This corresponds to measure A and B to compute A*B.

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -38,6 +38,8 @@ type GameType = Literal[
     "measure_3rd_quantum_multiplication",
 ]
 
+type SubCase = Literal["square_1", "square_2", "only_two_qubits"]
+
 
 @dataclasses.dataclass
 class ContextualityResult:
@@ -94,16 +96,19 @@ class ContextualityResult:
             Alice and Bob's choices in the game.
         """
         repetitions = self.alice_measurements.shape[2]
+
+        # the following two arrays have indices signifying
+        # [query_row, query_column, repetition, index_of_output]
         alice_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
         bob_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
 
-        alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1]
-        alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]
-        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]
-        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]
-        bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1]
-        bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0]
-        bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2]
+        alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1]  # I ⊗ Z
+        alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]  # Z ⊗ I
+        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]  # X ⊗ I | I ⊗ X
+        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]  # -X ⊗ Z |-Z ⊗ X
+        bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1]  # I ⊗ Z
+        bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0]  # X ⊗ I
+        bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2]  # Z ⊗ I | I ⊗ X
 
         alice_choices[:, :, :, 2] = 1 - self.alice_measurements[:, :, :, 2]
 
@@ -127,16 +132,19 @@ class ContextualityResult:
             Alice and Bob's choices in the game.
         """
         repetitions = self.alice_measurements.shape[2]
+
+        # the following two arrays have indices signifying
+        # [query_row, query_column, repetition, index_of_output]
         alice_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
         bob_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
 
-        alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1]
-        alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]
-        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]
-        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]
-        bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1]
-        bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0]
-        bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2]
+        alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1]  # I ⊗ Z
+        alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]  # Z ⊗ I
+        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]  # X ⊗ I | I ⊗ X
+        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]  # -X ⊗ Z |-Z ⊗ X
+        bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1]  # I ⊗ Z
+        bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0]  # X ⊗ I
+        bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2]  # Z ⊗ I | I ⊗ X
 
         alice_choices[:, :, :, 2] = self.alice_measurements[:, :, :, 2]
         bob_choices[:, 0, :, 2] = 1 - self.bob_measurements[:, 0, :, 2]
@@ -314,7 +322,7 @@ def run_contextuality_experiment(
     alice_qubits: list[cirq.GridQubit],
     bob_qubits: list[cirq.GridQubit],
     game: GameType,
-    sub_case: Literal["square_1", "square_2", "only_two_qubits"],
+    sub_case: SubCase,
     repetitions: int = 10_000,
     add_dd: bool = True,
     dd_scheme: tuple[cirq.Gate, ...] = (cirq.X, cirq.Y, cirq.X, cirq.Y),
@@ -402,7 +410,7 @@ def run_contextuality_experiment(
 
 
 def multiply_bool(bool_0: list[bool], bool_1: list[bool]) -> list[bool]:
-    """Perform boolean multiplication. Useful for "measure_3rd_classical_multiplication".""""
+    """Perform boolean multiplication. Useful for "measure_3rd_classical_multiplication"."""
     return [el0 == el1 for el0, el1 in zip(bool_0, bool_1)]
 
 
@@ -442,7 +450,7 @@ def construct_measure_circuit(
     mermin_row: int,
     mermin_col: int,
     game: GameType,
-    sub_case: Literal["square_1", "square_2", "only_two_qubits"],
+    sub_case: SubCase,
 ) -> cirq.Circuit:
     """Construct a circuit to implement the measurement.
 
@@ -710,7 +718,7 @@ def construct_contextuality_circuit(
     mermin_col: int,
     add_dd: bool,
     game: GameType,
-    sub_case: Literal["square_1", "square_2", "only_two_qubits"],
+    sub_case: SubCase,
     dd_scheme: tuple[cirq.Gate, ...] = (cirq.X, cirq.Y, cirq.X, cirq.Y),
 ) -> cirq.Circuit:
     """Construct a circuit to implement the contextuality experiment on hardware.

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -72,16 +72,16 @@ class ContextualityResult:
 
         # the following manipulations implment the Mermin-Peres square from the
         # docstring of `construct_contextuality_circuit`
-        alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1] # I ⊗ Z
-        alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0] # Z ⊗ I
-        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2] # X ⊗ I | I ⊗ X
-        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2] # -X ⊗ Z |-Z ⊗ X
-        bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1] # I ⊗ Z
-        bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0] # X ⊗ I
-        bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2] # Z ⊗ I | I ⊗ X
+        alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1]  # I ⊗ Z
+        alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]  # Z ⊗ I
+        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]  # X ⊗ I | I ⊗ X
+        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]  # -X ⊗ Z |-Z ⊗ X
+        bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1]  # I ⊗ Z
+        bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0]  # X ⊗ I
+        bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2]  # Z ⊗ I | I ⊗ X
 
-        alice_choices[:, :, :, 2] = np.sum(alice_choices, axis=3) % 2 # infer from rule
-        bob_choices[:, :, :, 2] = 1 - (np.sum(bob_choices, axis=3) % 2) # infer from rule
+        alice_choices[:, :, :, 2] = np.sum(alice_choices, axis=3) % 2  # infer from rule
+        bob_choices[:, :, :, 2] = 1 - (np.sum(bob_choices, axis=3) % 2)  # infer from rule
         return alice_choices, bob_choices
 
     def _generate_choices_from_rules_measure_3rd_classical_multiplication(

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -168,8 +168,9 @@ class ContextualityResult:
             raise ValueError(f"Unknown game: {game}")
 
     def get_agree_given_multiply_matrix(self, game: GameType) -> np.ndarray:
-        """Find the fraction of the time that Alice and Bob "agree" (in the intersection) given that
-        they "multiply correctly" (alice to -1 and bob to +1).
+        """Fraction of time Alice and Bob agree in the intersection when they multiply correctly.
+
+        Alice should multiply to +1 and Bob to -1.
 
         Args:
             game:
@@ -203,8 +204,9 @@ class ContextualityResult:
         return agree_given_multiply_matrix
 
     def get_multiply_matrix(self, game: GameType) -> np.ndarray:
-        """Find the fraction of the time that Alice and Bob
-        "multiply correctly" (alice to -1 and bob to +1).
+        """Fraction of the time that Alice and Bob multiply correctly.
+
+        Alice should multiply to +1 and Bob to -1.
 
         Args:
             game:
@@ -233,7 +235,7 @@ class ContextualityResult:
         return multiply_matrix
 
     def get_agree_matrix(self, game: GameType) -> np.ndarray:
-        """Fraction of the time that Alice and Bob Alice and Bob "agree" (in the intersection).
+        """Fraction of the time that Alice and Bob agree in the intersection.
 
         Args:
             game:

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -261,10 +261,8 @@ class ContextualityResult:
         return agree_matrix
 
     def get_agree_and_multiply_matrix(self, game: GameType) -> np.ndarray:
-        """Find the fraction of the time that Alice and Bob
-        Alice and Bob "agree" (in the intersection)
-        and
-        they "multiply correctly" (alice to -1 and bob to +1).
+        """Find the fraction of the time that Alice and Bob "agree" (in the intersection)
+        and they "multiply correctly" (alice to -1 and bob to +1).
 
         Args:
             game:

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -27,7 +27,7 @@ simultaneously with fixed values.
 """
 
 import dataclasses
-from typing import Any, Literal
+from typing import Literal
 
 import cirq
 import numpy as np

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -38,7 +38,7 @@ GameType = Literal[
     "measure_3rd_quantum_multiplication",
 ]
 
-SubCase = Literal["square_1", "square_2", "only_two_qubits"]
+SubCase = Literal["standard", "two_qubits"]
 
 
 @dataclasses.dataclass
@@ -67,8 +67,12 @@ class ContextualityResult:
 
         alice_choices[0, :, :, 0] = self.alice_measurements[0, :, :, 1]  # I ⊗ Z
         alice_choices[0, :, :, 1] = self.alice_measurements[0, :, :, 0]  # Z ⊗ I
-        alice_choices[1, :, :, :2] = self.alice_measurements[1, :, :, :2]  # X ⊗ I | I ⊗ X
-        alice_choices[2, :, :, :2] = 1 - self.alice_measurements[2, :, :, :2]  # -X ⊗ Z |-Z ⊗ X
+        alice_choices[1, :, :, :2] = self.alice_measurements[
+            1, :, :, :2
+        ]  # X ⊗ I | I ⊗ X
+        alice_choices[2, :, :, :2] = (
+            1 - self.alice_measurements[2, :, :, :2]
+        )  # -X ⊗ Z |-Z ⊗ X
         bob_choices[:, 0, :, 0] = self.bob_measurements[:, 0, :, 1]  # I ⊗ Z
         bob_choices[:, 0, :, 1] = self.bob_measurements[:, 0, :, 0]  # X ⊗ I
         bob_choices[:, 1:, :, :2] = self.bob_measurements[:, 1:, :, :2]  # Z ⊗ I | I ⊗ X
@@ -76,8 +80,7 @@ class ContextualityResult:
         return alice_choices, bob_choices
 
     def _generate_choices_from_rules_infer_3rd(self) -> tuple[np.ndarray, np.ndarray]:
-        """Generate choices from Alice and Bob's measurements by inferring the third number from the
-        first two.
+        """Generate choices by inferring the third measurement from the first two.
 
         Returns:
             Alice and Bob's choices in the game.
@@ -85,14 +88,15 @@ class ContextualityResult:
         alice_choices, bob_choices = self._assign_choices_from_measurements()
 
         alice_choices[:, :, :, 2] = np.sum(alice_choices, axis=3) % 2  # infer from rule
-        bob_choices[:, :, :, 2] = 1 - (np.sum(bob_choices, axis=3) % 2)  # infer from rule
+        bob_choices[:, :, :, 2] = 1 - (
+            np.sum(bob_choices, axis=3) % 2
+        )  # infer from rule
         return alice_choices, bob_choices
 
     def _generate_choices_from_rules_measure_3rd_classical_multiplication(
         self,
     ) -> tuple[np.ndarray, np.ndarray]:
-        """Generate choices from Alice and Bob's measurements by measuring
-        two one-body observables and making a classical multiplication to get the result
+        """Generate choices by measuring two one-body observables and multiplying classically.
 
         Returns:
             Alice and Bob's choices in the game.
@@ -114,8 +118,7 @@ class ContextualityResult:
     def _generate_choices_from_rules_measure_3rd_quantum_multiplication(
         self,
     ) -> tuple[np.ndarray, np.ndarray]:
-        """Generate choices from Alice and Bob's measurements by measuring
-        one two body operator for the third observable.
+        """Generate choices by measuring one two-body operator for the third observable.
 
         Returns:
             Alice and Bob's choices in the game.
@@ -137,7 +140,7 @@ class ContextualityResult:
 
         Args:
             game:
-                infer_3rd means making two measurements and inferring the third bit
+                "infer_3rd": make two measurements and infer the third bit.
                 "measure_3rd_classical_multiplication": make 4 measurements for Alice and 4 for Bob.
                 get three bits out of them by multiplying two of them together.
                 This corresponds to measure A and B to compute A*B.
@@ -153,10 +156,16 @@ class ContextualityResult:
         """
         if game == "infer_3rd":
             return self._generate_choices_from_rules_infer_3rd()
-        if game == "measure_3rd_classical_multiplication":
-            return self._generate_choices_from_rules_measure_3rd_classical_multiplication()
-        if game == "measure_3rd_quantum_multiplication":
-            return self._generate_choices_from_rules_measure_3rd_quantum_multiplication()
+        elif game == "measure_3rd_classical_multiplication":
+            return (
+                self._generate_choices_from_rules_measure_3rd_classical_multiplication()
+            )
+        elif game == "measure_3rd_quantum_multiplication":
+            return (
+                self._generate_choices_from_rules_measure_3rd_quantum_multiplication()
+            )
+        else:
+            raise ValueError(f"Unknown game: {game}")
 
     def get_agree_given_multiply_matrix(self, game: GameType) -> np.ndarray:
         """Find the fraction of the time that Alice and Bob "agree" (in the intersection) given that
@@ -164,7 +173,7 @@ class ContextualityResult:
 
         Args:
             game:
-                infer_3rd means making two measurements and inferring the third bit
+                "infer_3rd": make two measurements and infer the third bit.
                 "measure_3rd_classical_multiplication": make 4 measurements for Alice and 4 for Bob.
                 get three bits out of them by multiplying two of them together.
                 This corresponds to measure A and B to compute A*B.
@@ -177,7 +186,6 @@ class ContextualityResult:
         alice_choices, bob_choices = self.generate_choices(game)
         agree_given_multiply_matrix = np.zeros((3, 3))
         repetitions = alice_choices.shape[2]
-        print(f"{repetitions=}")
         for row in range(3):
             for col in range(3):
                 # if multiplication rules are not respected, there is no match
@@ -189,7 +197,6 @@ class ContextualityResult:
                         number_of_matches += 1
                         if alice_triad[col] == bob_triad[row]:
                             agree_given_multiply_matrix[row, col] += 1
-                print("Times they both multiply correctly to +-1 =", number_of_matches)
                 agree_given_multiply_matrix[row, col] = (
                     agree_given_multiply_matrix[row, col] / number_of_matches
                 )
@@ -201,7 +208,7 @@ class ContextualityResult:
 
         Args:
             game:
-                infer_3rd means making two measurements and inferring the third bit
+                "infer_3rd": make two measurements and infer the third bit.
                 "measure_3rd_classical_multiplication": make 4 measurements for Alice and 4 for Bob.
                 get three bits out of them by multiplying two of them together.
                 This corresponds to measure A and B to compute A*B.
@@ -214,7 +221,6 @@ class ContextualityResult:
         alice_choices, bob_choices = self.generate_choices(game)
         multiply_matrix = np.zeros((3, 3))
         repetitions = alice_choices.shape[2]
-        print(f"{repetitions=}")
         for row in range(3):
             for col in range(3):
                 for rep in range(repetitions):
@@ -231,7 +237,7 @@ class ContextualityResult:
 
         Args:
             game:
-                "infer_3rd": making two measurements and inferring the third bit
+                "infer_3rd": make two measurements and infer the third bit.
                 "measure_3rd_classical_multiplication": make 4 measurements for Alice and 4 for Bob.
                 get three bits out of them by multiplying two of them together.
                 This corresponds to measure A and B to compute A*B.
@@ -244,7 +250,6 @@ class ContextualityResult:
         alice_choices, bob_choices = self.generate_choices(game)
         agree_matrix = np.zeros((3, 3))
         repetitions = alice_choices.shape[2]
-        print(f"{repetitions=}")
         for row in range(3):
             for col in range(3):
                 for rep in range(repetitions):
@@ -276,7 +281,6 @@ class ContextualityResult:
         alice_choices, bob_choices = self.generate_choices(game)
         agree_and_multiply_matrix = np.zeros((3, 3))
         repetitions = alice_choices.shape[2]
-        print(f"{repetitions=}")
         for row in range(3):
             for col in range(3):
                 for rep in range(repetitions):
@@ -288,7 +292,9 @@ class ContextualityResult:
                         and np.sum(bob_triad) % 2 == 1
                     ):
                         agree_and_multiply_matrix[row, col] += 1
-                agree_and_multiply_matrix[row, col] = agree_and_multiply_matrix[row, col] / repetitions
+                agree_and_multiply_matrix[row, col] = (
+                    agree_and_multiply_matrix[row, col] / repetitions
+                )
         return agree_and_multiply_matrix
 
 
@@ -321,9 +327,8 @@ def run_contextuality_experiment(
                 "measure_3rd_quantum_multiplication": make 3 measurements for Alice and 3 for Bob.
                 Use a two qubit interaction to directly measure A*B.
         sub_case:
-            square1 is the wikipedia square: https://en.wikipedia.org/wiki/Quantum_pseudo-telepathy
-            square2 is not implemented, all blocks have 2body observables
-            only_two_qubits means with 4q total (2 per player). Can only do infer_3rd
+            standard is the wikipedia square: https://en.wikipedia.org/wiki/Quantum_pseudo-telepathy
+            two_qubits means with 4q total (2 per player). Can only do infer_3rd
 
     Returns:
         A ContextualityResult object containing the experiment results.
@@ -352,14 +357,17 @@ def run_contextuality_experiment(
 
     for row in range(3):
         for col in range(3):
-            if sub_case == "only_two_qubits":
+            if sub_case == "two_qubits":
                 alice_measurements[row, col, :, :2] = results[idx][0].measurements[
                     "alice_datas"
                 ]
-
-                bob_measurements[row, col, :, :2] = results[idx][0].measurements["bob_datas"]
+                bob_measurements[row, col, :, :2] = results[idx][0].measurements[
+                    "bob_datas"
+                ]
             else:
-                alice_measurements[row, col, :, :2] = results[idx][0].measurements["alice"]
+                alice_measurements[row, col, :, :2] = results[idx][0].measurements[
+                    "alice"
+                ]
                 bob_measurements[row, col, :, :2] = results[idx][0].measurements["bob"]
 
             if game == "measure_3rd_classical_multiplication":
@@ -375,9 +383,9 @@ def run_contextuality_experiment(
                 alice_measurements[row, col, :, 2] = results[idx][0].measurements[
                     "alice_datas"
                 ][:, 0]
-                bob_measurements[row, col, :, 2] = results[idx][0].measurements["bob_datas"][
-                    :, 0
-                ]
+                bob_measurements[row, col, :, 2] = results[idx][0].measurements[
+                    "bob_datas"
+                ][:, 0]
 
             idx += 1
 
@@ -415,7 +423,10 @@ def state_prep_circuit(
     Returns:
         A circuit preparing the Bell states.
     """
-    pairs = ((alice_data_qubits[0], bob_data_qubits[0]), (alice_data_qubits[1], bob_data_qubits[1]))
+    pairs = (
+        (alice_data_qubits[0], bob_data_qubits[0]),
+        (alice_data_qubits[1], bob_data_qubits[1]),
+    )
     return bell_pair_prep_circuit(*pairs[0]).zip(bell_pair_prep_circuit(*pairs[1]))
 
 
@@ -460,13 +471,13 @@ def construct_measure_circuit(
     q = alice_qubits[1:3]  # data qubits
     m = (alice_qubits[0], alice_qubits[3])  # measure qubits
     if mermin_row == 0:
-        if sub_case == "square_1":
+        if sub_case == "standard":
             alice_circuit = cirq.Circuit(
-                # map datas into two measures to measure I ⊗ Z  and Z ⊗ I on them
+                # Map data into two measures to measure I ⊗ Z  and Z ⊗ I on them.
                 cirq.H.on_each(*m),
                 cirq.CZ.on_each(*zip(m, q)),
                 cirq.H.on_each(*m),
-                # map the two datas onto the second data
+                # Map the two data onto the second data.
                 cirq.Moment(cirq.M(*m, key="alice")),
             )
 
@@ -476,23 +487,29 @@ def construct_measure_circuit(
                 alice_circuit.append(cirq.M(*q, key="alice_datas"))
 
             elif game == "measure_3rd_quantum_multiplication":
-                alice_circuit.append([
-                    cirq.H.on(q[1]),
-                    cirq.CZ.on(*q),
-                    cirq.H.on(q[1]),
-                    cirq.M(q[1], key="alice_datas"),
-                ])
+                alice_circuit.append(
+                    [
+                        cirq.H.on(q[1]),
+                        cirq.CZ.on(*q),
+                        cirq.H.on(q[1]),
+                        cirq.M(q[1], key="alice_datas"),
+                    ]
+                )
 
-        if sub_case == "only_two_qubits":
+        elif sub_case == "two_qubits":
             alice_circuit = cirq.Circuit(cirq.Moment(cirq.M(*q, key="alice_datas")))
 
             if game == "infer_3rd":
                 pass
             else:
-                raise ValueError("You can only game = infer_3rd if you sub_case = only_two_qubits")
+                raise ValueError(
+                    "You can only game = infer_3rd if you sub_case = two_qubits"
+                )
+        else:
+            raise ValueError(f"Unsupported sub_case: {sub_case}")
 
     elif mermin_row == 1:
-        if sub_case == "square_1":
+        if sub_case == "standard":
             alice_circuit = cirq.Circuit(
                 cirq.H.on_each(*q, *m),
                 cirq.CZ.on_each(*zip(q, m)),
@@ -502,30 +519,36 @@ def construct_measure_circuit(
 
             if game == "infer_3rd":
                 pass
-
             elif game == "measure_3rd_classical_multiplication":
                 alice_circuit.append(cirq.M(*q, key="alice_datas"))
 
             elif game == "measure_3rd_quantum_multiplication":
-                alice_circuit.append([
-                    cirq.H.on(q[1]),
-                    cirq.CZ.on(*q),
-                    cirq.H.on(q[1]),
-                    cirq.M(q[1], key="alice_datas"),
-                ])
+                alice_circuit.append(
+                    [
+                        cirq.H.on(q[1]),
+                        cirq.CZ.on(*q),
+                        cirq.H.on(q[1]),
+                        cirq.M(q[1], key="alice_datas"),
+                    ]
+                )
 
-        if sub_case == "only_two_qubits":
+        elif sub_case == "two_qubits":
             alice_circuit = cirq.Circuit(
-                cirq.Moment(cirq.H.on_each(*q)), cirq.Moment(cirq.M(*q, key="alice_datas"))
+                cirq.Moment(cirq.H.on_each(*q)),
+                cirq.Moment(cirq.M(*q, key="alice_datas")),
             )
 
             if game == "infer_3rd":
                 pass
             else:
-                raise ValueError("You can only game = infer_3rd if you sub_case = only_two_qubits")
+                raise ValueError(
+                    "You can only game = infer_3rd if you sub_case = two_qubits"
+                )
+        else:
+            raise ValueError(f"Unsupported sub_case: {sub_case}")
 
     elif mermin_row == 2:
-        if sub_case == "square_1":
+        if sub_case == "standard":
             alice_circuit = cirq.Circuit(
                 cirq.CZ(*q),
                 cirq.Moment(cirq.H.on_each(*q, *m)),
@@ -539,23 +562,24 @@ def construct_measure_circuit(
             if game == "infer_3rd":
                 pass
             elif game == "measure_3rd_classical_multiplication":
-                alice_circuit.append([
-                    cirq.Rx(rads=np.pi / 2).on_each(*q),
-                    cirq.M(*q, key="alice_datas"),
-                ])
-
-
+                alice_circuit.append(
+                    [
+                        cirq.Rx(rads=np.pi / 2).on_each(*q),
+                        cirq.M(*q, key="alice_datas"),
+                    ]
+                )
             elif game == "measure_3rd_quantum_multiplication":
-                alice_circuit.append([
-                    cirq.Rx(rads=np.pi / 2).on_each(*q),
-                    cirq.H.on(q[1]),
-                    cirq.CZ.on(*q),
-                    cirq.H.on(q[1]),
-                    cirq.M(q[1], key="alice_datas"),
-                ])
+                alice_circuit.append(
+                    [
+                        cirq.Rx(rads=np.pi / 2).on_each(*q),
+                        cirq.H.on(q[1]),
+                        cirq.CZ.on(*q),
+                        cirq.H.on(q[1]),
+                        cirq.M(q[1], key="alice_datas"),
+                    ]
+                )
 
-
-        if sub_case == "only_two_qubits":
+        elif sub_case == "two_qubits":
             alice_circuit = cirq.Circuit(
                 cirq.ry(np.pi / 2)(q[0]),
                 cirq.H.on(q[0]),
@@ -568,14 +592,20 @@ def construct_measure_circuit(
             if game == "infer_3rd":
                 pass
             else:
-                raise ValueError("You can only game = infer_3rd if you sub_case = only_two_qubits")
+                raise ValueError(
+                    "You can only game = infer_3rd if you sub_case = two_qubits"
+                )
+        else:
+            raise ValueError(f"Unsupported sub_case: {sub_case}")
+    else:
+        raise ValueError(f"Invalid mermin_row: {mermin_row}")
 
     q = bob_qubits[1:3]  # data qubits
     m = (bob_qubits[0], bob_qubits[3])  # measure qubits
     if mermin_col == 0:
-        if sub_case == "square_1":
+        if sub_case == "standard":
             bob_circuit = cirq.Circuit(
-                # map datas onto measures to measure I ⊗ Z and X ⊗ I on them
+                # Map data onto measures to measure I ⊗ Z and X ⊗ I on them.
                 cirq.H.on_each(*m, q[0]),
                 cirq.CZ.on_each(*zip(m, q)),
                 cirq.H.on_each(*m),
@@ -586,28 +616,34 @@ def construct_measure_circuit(
                 pass
             elif game == "measure_3rd_classical_multiplication":
                 bob_circuit.append(cirq.M(*q, key="bob_datas"))
-
-
             elif game == "measure_3rd_quantum_multiplication":
-                bob_circuit.append([
-                    cirq.H.on(q[1]),
-                    cirq.CZ.on(*q),
-                    cirq.H.on(q[1]),
-                    cirq.M(q[1], key="bob_datas"),
-                ])
+                bob_circuit.append(
+                    [
+                        cirq.H.on(q[1]),
+                        cirq.CZ.on(*q),
+                        cirq.H.on(q[1]),
+                        cirq.M(q[1], key="bob_datas"),
+                    ]
+                )
 
-        if sub_case == "only_two_qubits":
-            bob_circuit = cirq.Circuit(cirq.H.on(q[0]), cirq.Moment(cirq.M(*q, key="bob_datas")))
+        elif sub_case == "two_qubits":
+            bob_circuit = cirq.Circuit(
+                cirq.H.on(q[0]), cirq.Moment(cirq.M(*q, key="bob_datas"))
+            )
 
             if game == "infer_3rd":
                 pass
             else:
-                raise ValueError("You can only game = infer_3rd if you sub_case = only_two_qubits")
+                raise ValueError(
+                    "You can only game = infer_3rd if you sub_case = two_qubits"
+                )
+        else:
+            raise ValueError(f"Unsupported sub_case: {sub_case}")
 
     elif mermin_col == 1:
-        if sub_case == "square_1":
+        if sub_case == "standard":
             bob_circuit = cirq.Circuit(
-                # map datas onto measures to measure Z ⊗ I and I ⊗ X on them
+                # Map data onto measures to measure Z ⊗ I and I ⊗ X on them.
                 cirq.H.on_each(*m, q[1]),
                 cirq.CZ.on_each(*zip(m, q)),
                 cirq.H.on_each(*m),
@@ -620,31 +656,37 @@ def construct_measure_circuit(
                 bob_circuit.append(cirq.M(*q, key="bob_datas"))
 
             elif game == "measure_3rd_quantum_multiplication":
-                bob_circuit.append([
-                    cirq.H.on(q[1]),
-                    cirq.CZ.on(*q),
-                    cirq.H.on(q[1]),
-                    cirq.M(q[1], key="bob_datas"),
-                ])
+                bob_circuit.append(
+                    [
+                        cirq.H.on(q[1]),
+                        cirq.CZ.on(*q),
+                        cirq.H.on(q[1]),
+                        cirq.M(q[1], key="bob_datas"),
+                    ]
+                )
 
-
-        if sub_case == "only_two_qubits":
-            bob_circuit = cirq.Circuit(cirq.H.on(q[1]), cirq.Moment(cirq.M(*q, key="bob_datas")))
+        elif sub_case == "two_qubits":
+            bob_circuit = cirq.Circuit(
+                cirq.H.on(q[1]), cirq.Moment(cirq.M(*q, key="bob_datas"))
+            )
 
             if game == "infer_3rd":
                 pass
             else:
-                raise ValueError("You can only game = infer_3rd if you sub_case = only_two_qubits")
+                raise ValueError(
+                    "You can only game = infer_3rd if you sub_case = two_qubits"
+                )
+        else:
+            raise ValueError(f"Unsupported sub_case: {sub_case}")
 
     elif mermin_col == 2:
-        if sub_case == "square_1":
+        if sub_case == "standard":
             bob_circuit = cirq.Circuit(
                 cirq.H(q[0]),
                 cirq.CZ(*q),
                 cirq.Moment(cirq.H.on_each(*q, *m)),
                 cirq.CZ.on_each(*zip(m, q)),
                 cirq.H.on_each(*m),
-                # re-add Eliott's dropped to circuit
                 cirq.Moment(cirq.H.on_each(*q)),
                 cirq.CZ(*q),
                 cirq.H(q[0]),
@@ -654,37 +696,44 @@ def construct_measure_circuit(
             if game == "infer_3rd":
                 pass
             elif game == "measure_3rd_classical_multiplication":
-                bob_circuit.append([
-                    cirq.Rx(rads=np.pi / 2).on_each(*q),
-                    cirq.M(*q, key="bob_datas"),
-                ])
+                bob_circuit.append(
+                    [
+                        cirq.Rx(rads=np.pi / 2).on_each(*q),
+                        cirq.M(*q, key="bob_datas"),
+                    ]
+                )
 
             elif game == "measure_3rd_quantum_multiplication":
-                bob_circuit.append([
-                    cirq.Rx(rads=np.pi / 2).on_each(*q),
-                    cirq.H.on(q[1]),
-                    cirq.CZ.on(*q),
-                    cirq.H.on(q[1]),
-                    cirq.M(q[1], key="bob_datas"),
-                ])
+                bob_circuit.append(
+                    [
+                        cirq.Rx(rads=np.pi / 2).on_each(*q),
+                        cirq.H.on(q[1]),
+                        cirq.CZ.on(*q),
+                        cirq.H.on(q[1]),
+                        cirq.M(q[1], key="bob_datas"),
+                    ]
+                )
 
-
-
-        if sub_case == "only_two_qubits":
+        elif sub_case == "two_qubits":
             bob_circuit = cirq.Circuit(
-                cirq.H.on(q[0]),
+                cirq.H(q[0]),
                 cirq.CZ.on(*q),
                 cirq.H.on_each(*q),
                 cirq.Moment(cirq.M(*q, key="bob_datas")),
             )
 
-
-
             if game == "infer_3rd":
                 pass
             else:
-                raise ValueError("You can only sub_case = only_two_qubits if game = infer_3rd")
+                raise ValueError(
+                    "You can only sub_case = two_qubits if game = infer_3rd"
+                )
+        else:
+            raise ValueError(f"Unsupported sub_case: {sub_case}")
+    else:
+        raise ValueError(f"Invalid mermin_col: {mermin_col}")
     return cirq.align_right(alice_circuit + bob_circuit)
+
 
 def construct_contextuality_circuit(
     alice_qubits: list[cirq.GridQubit],
@@ -725,7 +774,7 @@ def construct_contextuality_circuit(
     """
     alice_data_qubits = (alice_qubits[1], alice_qubits[2])
     bob_data_qubits = (bob_qubits[1], bob_qubits[2])
-    prep_circuit = state_prep_circuit(alice_data_qubits, bob_data_qubits)  # test cirq.Circuit() #
+    prep_circuit = state_prep_circuit(alice_data_qubits, bob_data_qubits)
     measure_circuit = construct_measure_circuit(
         alice_qubits, bob_qubits, mermin_row, mermin_col, game, sub_case
     )

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -60,8 +60,8 @@ class ContextualityResult:
 
         repetitions = self.alice_measurements.shape[2]
 
-        # the following two arrays have indices signifying
-        # [query_row, query_column, repetition, index_of_output]
+        # The following two arrays have indices signifying
+        # [query_row, query_column, repetition, index_of_output].
         alice_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
         bob_choices = np.zeros((3, 3, repetitions, 3), dtype=bool)
 

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -188,7 +188,7 @@ class ContextualityResult:
         repetitions = alice_choices.shape[2]
         for row in range(3):
             for col in range(3):
-                # if multiplication rules are not respected, there is no match
+                # If multiplication rules are not respected, there is no match.
                 number_of_matches = 0
                 for rep in range(repetitions):
                     alice_triad = alice_choices[row, col, rep, :]

--- a/recirq/contextuality/magic_square_game.py
+++ b/recirq/contextuality/magic_square_game.py
@@ -261,8 +261,9 @@ class ContextualityResult:
         return agree_matrix
 
     def get_agree_and_multiply_matrix(self, game: GameType) -> np.ndarray:
-        """Find the fraction of the time that Alice and Bob "agree" (in the intersection)
-        and they "multiply correctly" (alice to -1 and bob to +1).
+        """Fraction of the time that Alice and Bob agree in the intersection and multiply correctly.
+
+        Alice should multiply to +1 and Bob to -1.
 
         Args:
             game:

--- a/recirq/contextuality/magic_square_game_test.py
+++ b/recirq/contextuality/magic_square_game_test.py
@@ -25,7 +25,7 @@ def test_run_contextuality_experiment(game: msg.GameType, add_dd: bool) -> None:
         sub_case="square_1",
         repetitions=10,
     )
-    assert np.all(result.get_win_matrix(game) == np.ones((3, 3)))
+    assert np.all(result.get_agree_given_multiply_matrix(game) == np.ones((3, 3)))
 
 
 @pytest.mark.parametrize(
@@ -44,6 +44,6 @@ def test_invalid_input_raises(game: msg.GameType, add_dd: bool):
             bob_qubits,
             game=game,
             add_dd=add_dd,
-            sub_case=sub_case,
+            sub_case="square_1",
             repetitions=10,
         )

--- a/recirq/contextuality/magic_square_game_test.py
+++ b/recirq/contextuality/magic_square_game_test.py
@@ -7,7 +7,7 @@ import recirq.contextuality.magic_square_game as msg
 
 @pytest.mark.parametrize(
     "game",
-    ["guess_3rd", "measure_3rd_classical_multiplication", "measure_3rd_quantum_multiplication"],
+    ["infer_3rd", "measure_3rd_classical_multiplication", "measure_3rd_quantum_multiplication"],
 )
 @pytest.mark.parametrize("add_dd", [True, False])
 def test_run_contextuality_experiment(game: msg.GameType, add_dd: bool) -> None:
@@ -30,20 +30,20 @@ def test_run_contextuality_experiment(game: msg.GameType, add_dd: bool) -> None:
 
 @pytest.mark.parametrize(
     "game",
-    ["guess_3rd", "measure_3rd_classical_multiplication", "measure_3rd_quantum_multiplication"],
+    ["infer_3rd", "measure_3rd_classical_multiplication", "measure_3rd_quantum_multiplication"],
 )
 @pytest.mark.parametrize("add_dd", [True, False])
 def test_invalid_input_raises(game: msg.GameType, add_dd: bool):
     sampler = cirq.Simulator()
     alice_qubits = cirq.GridQubit.rect(1, 4, 0, 0)  # test with 2 measure qubits
     bob_qubits = cirq.GridQubit.rect(1, 4, 1, 0)
-    with pytest.raises(ValueError, match="guess_3rd if you sub_case = only_two_qubits"):
+    with pytest.raises(ValueError, match="infer_3rd if you sub_case = only_two_qubits"):
         _ = msg.run_contextuality_experiment(
             sampler,
             alice_qubits,
             bob_qubits,
             game=game,
             add_dd=add_dd,
-            sub_case="square_1",
+            sub_case="only_two_qubits",
             repetitions=10,
         )

--- a/recirq/contextuality/magic_square_game_test.py
+++ b/recirq/contextuality/magic_square_game_test.py
@@ -1,0 +1,49 @@
+import cirq
+import numpy as np
+import pytest
+
+import recirq.contextuality.magic_square_game as msg
+
+
+@pytest.mark.parametrize(
+    "game",
+    ["guess_3rd", "measure_3rd_classical_multiplication", "measure_3rd_quantum_multiplication"],
+)
+@pytest.mark.parametrize("add_dd", [True, False])
+def test_run_contextuality_experiment(game: msg.GameType, add_dd: bool) -> None:
+    """Test that Alice and Bob win 100% of the time with a noiseless simulator."""
+
+    sampler = cirq.Simulator()
+    alice_qubits = cirq.GridQubit.rect(1, 4, 0, 0)  # test with 2 measure qubits
+    bob_qubits = cirq.GridQubit.rect(1, 4, 1, 0)
+    result = msg.run_contextuality_experiment(
+        sampler,
+        alice_qubits,
+        bob_qubits,
+        game=game,
+        add_dd=add_dd,
+        sub_case="square_1",
+        repetitions=10,
+    )
+    assert np.all(result.get_win_matrix(game) == np.ones((3, 3)))
+
+
+@pytest.mark.parametrize(
+    "game",
+    ["guess_3rd", "measure_3rd_classical_multiplication", "measure_3rd_quantum_multiplication"],
+)
+@pytest.mark.parametrize("add_dd", [True, False])
+def test_invalid_input_raises(game: msg.GameType, add_dd: bool):
+    sampler = cirq.Simulator()
+    alice_qubits = cirq.GridQubit.rect(1, 4, 0, 0)  # test with 2 measure qubits
+    bob_qubits = cirq.GridQubit.rect(1, 4, 1, 0)
+    with pytest.raises(ValueError, match="guess_3rd if you sub_case = only_two_qubits"):
+        _ = msg.run_contextuality_experiment(
+            sampler,
+            alice_qubits,
+            bob_qubits,
+            game=game,
+            add_dd=add_dd,
+            sub_case=sub_case,
+            repetitions=10,
+        )

--- a/recirq/contextuality/magic_square_game_test.py
+++ b/recirq/contextuality/magic_square_game_test.py
@@ -26,24 +26,3 @@ def test_run_contextuality_experiment(game: msg.GameType, add_dd: bool) -> None:
         repetitions=10,
     )
     assert np.all(result.get_agree_given_multiply_matrix(game) == np.ones((3, 3)))
-
-
-@pytest.mark.parametrize(
-    "game",
-    ["infer_3rd", "measure_3rd_classical_multiplication", "measure_3rd_quantum_multiplication"],
-)
-@pytest.mark.parametrize("add_dd", [True, False])
-def test_invalid_input_raises(game: msg.GameType, add_dd: bool):
-    sampler = cirq.Simulator()
-    alice_qubits = cirq.GridQubit.rect(1, 4, 0, 0)  # test with 2 measure qubits
-    bob_qubits = cirq.GridQubit.rect(1, 4, 1, 0)
-    with pytest.raises(ValueError, match="infer_3rd if you sub_case = only_two_qubits"):
-        _ = msg.run_contextuality_experiment(
-            sampler,
-            alice_qubits,
-            bob_qubits,
-            game=game,
-            add_dd=add_dd,
-            sub_case="only_two_qubits",
-            repetitions=10,
-        )

--- a/recirq/contextuality/magic_square_game_test.py
+++ b/recirq/contextuality/magic_square_game_test.py
@@ -7,7 +7,11 @@ import recirq.contextuality.magic_square_game as msg
 
 @pytest.mark.parametrize(
     "game",
-    ["infer_3rd", "measure_3rd_classical_multiplication", "measure_3rd_quantum_multiplication"],
+    [
+        "infer_3rd",
+        "measure_3rd_classical_multiplication",
+        "measure_3rd_quantum_multiplication",
+    ],
 )
 @pytest.mark.parametrize("add_dd", [True, False])
 def test_run_contextuality_experiment(game: msg.GameType, add_dd: bool) -> None:
@@ -22,7 +26,7 @@ def test_run_contextuality_experiment(game: msg.GameType, add_dd: bool) -> None:
         bob_qubits,
         game=game,
         add_dd=add_dd,
-        sub_case="square_1",
+        sub_case="standard",
         repetitions=10,
     )
     assert np.all(result.get_agree_given_multiply_matrix(game) == np.ones((3, 3)))


### PR DESCRIPTION
This PR adds a new experimental module to the ReCirq repository that implements the Mermin-Peres Magic Square game (a form of quantum pseudo-telepathy).

Specifically, this code:

- Adds new functionality: It provides a framework to run the game using cirq on both simulators and quantum hardware.

- Implements three experimental variations:

    1. infer_3rd: Measuring two observables and calculating the third classically.

    2. measure_3rd_classical_multiplication: Measuring components and multiplying the outcomes.

    3. measure_3rd_quantum_multiplication: Using two-qubit interactions to directly measure the product observable.

- Provides analysis tools: Includes a ContextualityResult class to calculate win rates, agreement matrices, and parity check fractions to verify quantum non-locality.

**Relevance to Contextuality Work**
The Magic Square game is a cornerstone "warm-up" experiment for demonstrating quantum contextuality (https://arxiv.org/pdf/2512.02284). It proves that measurement outcomes cannot be pre-determined independently of their "context" (which other measurements are performed simultaneously).

No new external libraries are required.