### PR TITLE
Use `-n auto` for pytest by default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
           # OMP_NUM_THREADS: PySCF's poor OpenMP performance slows down QCQMC tests.
           # RECIRQ_IMPORT_FAILSAFE: skip tests on unsupported Cirq configurations.
           export OMP_NUM_THREADS=1
-          RECIRQ_IMPORT_FAILSAFE=y pytest -n logical -v --skipslow
+          RECIRQ_IMPORT_FAILSAFE=y pytest -v --skipslow
 
   pylint:
     name: Run Python linters

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 markers =
     slow: marks tests as slow (deselect with '--skipslow')
+
+# Execute tests in parallel.
+addopts = -n auto


### PR DESCRIPTION
This adds `-n auto` to the top-level `pytest.ini` file and removes the  `-n` flag from invocations in the CI workflows. (The latter is because pytest will pick it up from the `pytest.ini` file now.)

Using parallelism speeds up pytest execution by a massive factor. I encountered no problems with it in testing, and the CI check workflows was already using it, so it looks safe to use as a default.