### PR TITLE
Add descriptive docstring for _get_phases in CZLayerGate

### DIFF
--- a/recirq/third_party/quaff/cz_layer.py
+++ b/recirq/third_party/quaff/cz_layer.py
@@ -144,7 +144,14 @@ class CZLayerGate(cirq.Gate):
         return phase_poly % 4
 
     def _get_phases(self):
-        """TODO"""
+        """Computes phase exponents for the single-qubit S gates in the decomposition.
+
+        Returns:
+            A tuple (linear, quadratic), where linear is a vector of exponents for
+            the initial single-qubit phase layer, and quadratic is a matrix where
+            each row s contains exponents for the single-qubit phase layer following
+            the s-th basis change stage.
+        """
         n = self.num_qubits()
         phase_poly = self.phase_poly
         quadratic = np.zeros((n // 2, n), dtype=linalg.DTYPE)


### PR DESCRIPTION
Replaced the "TODO" docstring with a detailed description of the parameters and return value for the _get_phases method, clarifying its role in the CZLayerGate's decomposition.