### PR TITLE
Support Cirq 1.7.0

### DIFF
--- a/dev_tools/write-ci-requirements.py
+++ b/dev_tools/write-ci-requirements.py
@@ -8,9 +8,9 @@ REPO_DIR = pathlib.Path(__file__).parent.parent.resolve()
 print('Repo dir:', REPO_DIR)
 
 CIRQ_VERSIONS = {
-    'previous': '~=1.5.0',
-    'current': '~=1.6.0',
-    'next': '>=1.7.0.dev',
+    'previous': '~=1.6.0',
+    'current': '~=1.7.0',
+    'next': '>=1.8.0.dev',
 }
 """Give names to relative Cirq versions so CI can have consistent names while versions
 get incremented."""

--- a/recirq/qcqmc/experiment.py
+++ b/recirq/qcqmc/experiment.py
@@ -19,7 +19,7 @@ import attrs
 import cirq
 import numpy as np
 import qsimcirq
-from pytz import timezone
+from zoneinfo import ZoneInfo
 
 from recirq.qcqmc import blueprint, config, data, for_refactor
 
@@ -172,7 +172,7 @@ def get_experimental_metadata() -> Dict[str, object]:
     """
 
     date_time = datetime.now()
-    pacific_tz = timezone("US/Pacific")
+    pacific_tz = ZoneInfo("US/Pacific")
     pacific_date_time = date_time.astimezone(pacific_tz)
 
     formatted_date_time = pacific_date_time.strftime("%m/%d/%Y, %H:%M:%S")


### PR DESCRIPTION
This updates the write-ci-requirements script to be consistent with the current version of Cirq (1.7.0). It also replaces the use of `pytz` with the package `timezone`. The former package was deprecated some time ago, and now when running pytest tests with the  next version of Cirq (1.8.0.dev0), a failure shows up in CI. Updating the references to timezones to use `timezone` instead of `pytz` makes the problem go away.