### PR TITLE
Pass seed to QSimSimulator in qcqmc tests

### DIFF
--- a/recirq/qcqmc/analysis_test.py
+++ b/recirq/qcqmc/analysis_test.py
@@ -90,7 +90,7 @@ def test_small_experiment_partition_match_reversed_partition_same_seed(
         n_samples_per_clifford=n_samples_per_clifford,
         noise_model_name="None",
         noise_model_params=(0,),
-        seed=2,
+        seed=1,
     )
 
     experiment_1 = ExperimentData.build_experiment_from_dependencies(

--- a/recirq/qcqmc/experiment.py
+++ b/recirq/qcqmc/experiment.py
@@ -143,7 +143,7 @@ def get_samples_from_simulation(
             circuits.
 
     """
-    simulator = qsimcirq.QSimSimulator()
+    simulator = qsimcirq.QSimSimulator(seed=seed)
 
     sampled_bitstrings = []
 


### PR DESCRIPTION
The work on PR https://github.com/quantumlib/ReCirq/pull/480 revealed that in `recirq/qcqmc/experiment.py`, a seed parameter was not being passed to the constructor for QSimSimulator. Fixing that (by passing the seed parameter to qsim) uncovered another small bug, this time in  `recirq/qcqmc/analysis_test.py` in function `test_small_experiment_partition_match_reversed_partition_same_seed`: the  experiments in that function were constructed with seed values that should have been the same, but weren't. Previously, this didn't matter because the seed values were not being passed to QSimSimulator anyway. With the change to experiment.py, though, one of the 3 cases in the parameterized runs of `test_small_experiment_partition_match_reversed_partition_same_seed` now fail.

Why does only 1 of 3 fail? It seems to be due to higher statistical variance in that first case, coming from the fact that the first case uses a small number of Clifford gates (10). This makes it influenced more by the seed value than the other cases. (The other cases work with `seed=1` and `seed=2`.)